### PR TITLE
Implement quick-add project creation form

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.0.9",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",

--- a/src/components/projects/CreateProjectForm.css
+++ b/src/components/projects/CreateProjectForm.css
@@ -1,0 +1,340 @@
+/**
+ * CreateProjectForm Styles
+ * Multi-step wizard form for quick project creation
+ */
+
+.create-project-form-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.form-header {
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.form-header h2 {
+  margin: 0 0 1rem 0;
+  font-size: 1.75rem;
+  color: #333;
+}
+
+.form-note {
+  padding: 1rem;
+  background-color: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: 4px;
+  color: #856404;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.form-note strong {
+  font-weight: 600;
+}
+
+/* Step Indicator */
+.step-indicator {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 3rem;
+  padding: 0 2rem;
+  position: relative;
+}
+
+.step-indicator::before {
+  content: '';
+  position: absolute;
+  top: 20px;
+  left: 10%;
+  right: 10%;
+  height: 2px;
+  background-color: #e0e0e0;
+  z-index: 0;
+}
+
+.step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+  flex: 1;
+}
+
+.step-number {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: #e0e0e0;
+  color: #666;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+  transition: all 0.3s ease;
+}
+
+.step.active .step-number {
+  background-color: #007bff;
+  color: white;
+}
+
+.step.completed .step-number {
+  background-color: #28a745;
+  color: white;
+}
+
+.step-label {
+  font-size: 0.85rem;
+  color: #666;
+  text-align: center;
+}
+
+.step.active .step-label {
+  color: #007bff;
+  font-weight: 600;
+}
+
+.step.completed .step-label {
+  color: #28a745;
+}
+
+/* Form Content */
+.form-content {
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 2rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.form-step h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.5rem;
+  color: #333;
+}
+
+.step-description {
+  margin: 0 0 2rem 0;
+  color: #666;
+  font-size: 0.95rem;
+}
+
+/* Form Groups */
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: #333;
+  font-size: 0.95rem;
+}
+
+.required {
+  color: #dc3545;
+}
+
+.form-group input,
+.form-group textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: #007bff;
+  box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.1);
+}
+
+.form-group input.error,
+.form-group textarea.error {
+  border-color: #dc3545;
+}
+
+.form-group input.error:focus,
+.form-group textarea.error:focus {
+  box-shadow: 0 0 0 3px rgba(220, 53, 69, 0.1);
+}
+
+.form-group textarea {
+  resize: vertical;
+  min-height: 100px;
+}
+
+.field-hint {
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: #666;
+}
+
+.error-message {
+  margin-top: 0.5rem;
+  color: #dc3545;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+}
+
+.error-message::before {
+  content: '⚠';
+  margin-right: 0.5rem;
+}
+
+.submit-error {
+  padding: 1rem;
+  background-color: #f8d7da;
+  border: 1px solid #f5c6cb;
+  border-radius: 4px;
+  margin-bottom: 1.5rem;
+}
+
+/* Confirmation Details */
+.confirmation-details {
+  background-color: #f8f9fa;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.detail-row {
+  display: flex;
+  margin-bottom: 1rem;
+}
+
+.detail-row:last-child {
+  margin-bottom: 0;
+}
+
+.detail-label {
+  font-weight: 600;
+  color: #333;
+  min-width: 150px;
+  flex-shrink: 0;
+}
+
+.detail-value {
+  color: #666;
+  word-break: break-word;
+}
+
+.detail-value em {
+  color: #999;
+}
+
+/* Form Actions */
+.form-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding-top: 2rem;
+  border-top: 1px solid #e0e0e0;
+}
+
+.btn-primary,
+.btn-secondary {
+  padding: 0.75rem 2rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  min-width: 120px;
+}
+
+.btn-primary {
+  background-color: #007bff;
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background-color: #0056b3;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px rgba(0, 123, 255, 0.3);
+}
+
+.btn-primary:disabled {
+  background-color: #6c757d;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.btn-secondary {
+  background-color: #6c757d;
+  color: white;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background-color: #5a6268;
+}
+
+.btn-secondary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .create-project-form-container {
+    padding: 1rem;
+  }
+
+  .step-indicator {
+    padding: 0 1rem;
+  }
+
+  .step-indicator::before {
+    left: 15%;
+    right: 15%;
+  }
+
+  .step-number {
+    width: 35px;
+    height: 35px;
+    font-size: 0.9rem;
+  }
+
+  .step-label {
+    font-size: 0.75rem;
+  }
+
+  .form-content {
+    padding: 1.5rem;
+  }
+
+  .form-step h3 {
+    font-size: 1.25rem;
+  }
+
+  .form-actions {
+    flex-direction: column;
+  }
+
+  .btn-primary,
+  .btn-secondary {
+    width: 100%;
+  }
+
+  .detail-row {
+    flex-direction: column;
+  }
+
+  .detail-label {
+    margin-bottom: 0.25rem;
+  }
+}

--- a/src/components/projects/CreateProjectForm.tsx
+++ b/src/components/projects/CreateProjectForm.tsx
@@ -1,0 +1,336 @@
+/**
+ * CreateProjectForm Component
+ * Quick-add form for creating simple projects without AI chat guidance
+ * Note: AI chat (Step 2) is the primary method with governance guidance
+ */
+
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useProject } from '../../contexts/ProjectContext';
+import { ProjectsService } from '../../services/api/projects';
+import { ApiClient } from '../../services/api/client';
+import './CreateProjectForm.css';
+
+interface FormData {
+  key: string;
+  name: string;
+  description: string;
+}
+
+interface FormErrors {
+  key?: string;
+  name?: string;
+  description?: string;
+  submit?: string;
+}
+
+type FormStep = 'basic' | 'settings' | 'confirmation';
+
+export const CreateProjectForm: React.FC = () => {
+  const navigate = useNavigate();
+  const { setCurrentProjectKey } = useProject();
+  
+  const [projectsService] = useState(() => 
+    new ProjectsService(
+      new ApiClient({ baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000' })
+    )
+  );
+  const [currentStep, setCurrentStep] = useState<FormStep>('basic');
+  const [formData, setFormData] = useState<FormData>({
+    key: '',
+    name: '',
+    description: '',
+  });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [loading, setLoading] = useState(false);
+
+  // Validate project key format (uppercase letters, numbers, hyphens)
+  const validateKey = (key: string): boolean => {
+    const keyRegex = /^[A-Z][A-Z0-9-]*$/;
+    return keyRegex.test(key);
+  };
+
+  // Validate current step fields
+  const validateStep = (step: FormStep): boolean => {
+    const newErrors: FormErrors = {};
+
+    if (step === 'basic') {
+      if (!formData.key.trim()) {
+        newErrors.key = 'Project key is required';
+      } else if (!validateKey(formData.key)) {
+        newErrors.key = 'Key must start with uppercase letter, contain only uppercase letters, numbers, and hyphens';
+      }
+
+      if (!formData.name.trim()) {
+        newErrors.name = 'Project name is required';
+      } else if (formData.name.trim().length < 3) {
+        newErrors.name = 'Project name must be at least 3 characters';
+      }
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  // Handle field changes
+  const handleChange = (field: keyof FormData, value: string) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+    // Clear error for this field
+    setErrors(prev => ({ ...prev, [field]: undefined }));
+  };
+
+  // Navigate to next step
+  const handleNext = () => {
+    if (!validateStep(currentStep)) {
+      return;
+    }
+
+    if (currentStep === 'basic') {
+      setCurrentStep('settings');
+    } else if (currentStep === 'settings') {
+      setCurrentStep('confirmation');
+    }
+  };
+
+  // Navigate to previous step
+  const handleBack = () => {
+    if (currentStep === 'settings') {
+      setCurrentStep('basic');
+    } else if (currentStep === 'confirmation') {
+      setCurrentStep('settings');
+    }
+  };
+
+  // Submit form to create project
+  const handleSubmit = async () => {
+    setLoading(true);
+    setErrors({});
+
+    try {
+      const projectData = {
+        key: formData.key.trim(),
+        name: formData.name.trim(),
+        description: formData.description.trim() || undefined,
+      };
+
+      const createdProject = await projectsService.createProject(projectData);
+      
+      // Set as current project
+      setCurrentProjectKey(createdProject.key);
+      
+      // Navigate to project dashboard (Issue #45 - when implemented)
+      // For now, navigate to project list
+      navigate('/projects');
+    } catch (error: any) {
+      console.error('Failed to create project:', error);
+      setErrors({
+        submit: error.message || 'Failed to create project. Please try again.',
+      });
+      setLoading(false);
+    }
+  };
+
+  // Cancel and return to project list
+  const handleCancel = () => {
+    navigate('/projects');
+  };
+
+  // Render step indicator
+  const renderStepIndicator = () => {
+    const steps: { id: FormStep; label: string }[] = [
+      { id: 'basic', label: 'Basic Info' },
+      { id: 'settings', label: 'Settings' },
+      { id: 'confirmation', label: 'Confirmation' },
+    ];
+
+    return (
+      <div className="step-indicator">
+        {steps.map((step, index) => (
+          <div
+            key={step.id}
+            className={`step ${currentStep === step.id ? 'active' : ''} ${
+              steps.findIndex(s => s.id === currentStep) > index ? 'completed' : ''
+            }`}
+          >
+            <div className="step-number">{index + 1}</div>
+            <div className="step-label">{step.label}</div>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  // Render basic info step
+  const renderBasicStep = () => (
+    <div className="form-step">
+      <h3>Basic Information</h3>
+      <p className="step-description">
+        Enter the basic details for your project.
+      </p>
+
+      <div className="form-group">
+        <label htmlFor="project-key">
+          Project Key <span className="required">*</span>
+        </label>
+        <input
+          id="project-key"
+          type="text"
+          value={formData.key}
+          onChange={e => handleChange('key', e.target.value.toUpperCase())}
+          placeholder="e.g., PROJ1"
+          className={errors.key ? 'error' : ''}
+          maxLength={20}
+          aria-invalid={!!errors.key}
+          aria-describedby={errors.key ? 'key-error' : undefined}
+        />
+        {errors.key && (
+          <div id="key-error" className="error-message" role="alert">
+            {errors.key}
+          </div>
+        )}
+        <div className="field-hint">
+          Unique identifier (uppercase, letters, numbers, hyphens)
+        </div>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="project-name">
+          Project Name <span className="required">*</span>
+        </label>
+        <input
+          id="project-name"
+          type="text"
+          value={formData.name}
+          onChange={e => handleChange('name', e.target.value)}
+          placeholder="e.g., My Project"
+          className={errors.name ? 'error' : ''}
+          maxLength={100}
+          aria-invalid={!!errors.name}
+          aria-describedby={errors.name ? 'name-error' : undefined}
+        />
+        {errors.name && (
+          <div id="name-error" className="error-message" role="alert">
+            {errors.name}
+          </div>
+        )}
+        <div className="field-hint">Display name for your project</div>
+      </div>
+
+      <div className="form-actions">
+        <button type="button" onClick={handleCancel} className="btn-secondary">
+          Cancel
+        </button>
+        <button type="button" onClick={handleNext} className="btn-primary">
+          Next
+        </button>
+      </div>
+    </div>
+  );
+
+  // Render settings step
+  const renderSettingsStep = () => (
+    <div className="form-step">
+      <h3>Project Settings</h3>
+      <p className="step-description">
+        Add optional details about your project.
+      </p>
+
+      <div className="form-group">
+        <label htmlFor="project-description">Description</label>
+        <textarea
+          id="project-description"
+          value={formData.description}
+          onChange={e => handleChange('description', e.target.value)}
+          placeholder="Brief description of your project (optional)"
+          rows={4}
+          maxLength={500}
+        />
+        <div className="field-hint">
+          {formData.description.length}/500 characters
+        </div>
+      </div>
+
+      <div className="form-actions">
+        <button type="button" onClick={handleBack} className="btn-secondary">
+          Back
+        </button>
+        <button type="button" onClick={handleNext} className="btn-primary">
+          Next
+        </button>
+      </div>
+    </div>
+  );
+
+  // Render confirmation step
+  const renderConfirmationStep = () => (
+    <div className="form-step">
+      <h3>Review & Confirm</h3>
+      <p className="step-description">
+        Please review your project details before creating.
+      </p>
+
+      <div className="confirmation-details">
+        <div className="detail-row">
+          <div className="detail-label">Project Key:</div>
+          <div className="detail-value">{formData.key}</div>
+        </div>
+        <div className="detail-row">
+          <div className="detail-label">Project Name:</div>
+          <div className="detail-value">{formData.name}</div>
+        </div>
+        <div className="detail-row">
+          <div className="detail-label">Description:</div>
+          <div className="detail-value">
+            {formData.description || <em>No description provided</em>}
+          </div>
+        </div>
+      </div>
+
+      {errors.submit && (
+        <div className="error-message submit-error" role="alert">
+          {errors.submit}
+        </div>
+      )}
+
+      <div className="form-actions">
+        <button
+          type="button"
+          onClick={handleBack}
+          className="btn-secondary"
+          disabled={loading}
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          className="btn-primary"
+          disabled={loading}
+        >
+          {loading ? 'Creating...' : 'Create Project'}
+        </button>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="create-project-form-container">
+      <div className="form-header">
+        <h2>Create New Project</h2>
+        <div className="form-note">
+          <strong>Note:</strong> This is a quick-add form for simple projects.
+          For projects requiring ISO 21500 governance guidance, use the{' '}
+          <strong>AI Chat workflow (Step 2)</strong>.
+        </div>
+      </div>
+
+      {renderStepIndicator()}
+
+      <div className="form-content">
+        {currentStep === 'basic' && renderBasicStep()}
+        {currentStep === 'settings' && renderSettingsStep()}
+        {currentStep === 'confirmation' && renderConfirmationStep()}
+      </div>
+    </div>
+  );
+};

--- a/src/test/unit/components/projects/CreateProjectForm.test.tsx
+++ b/src/test/unit/components/projects/CreateProjectForm.test.tsx
@@ -1,0 +1,488 @@
+/**
+ * CreateProjectForm Tests
+ * Comprehensive test suite for the multi-step project creation form
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+import { ProjectProvider } from '../../../../contexts/ProjectContext';
+import { CreateProjectForm } from '../../../../components/projects/CreateProjectForm';
+import { ProjectsService } from '../../../../services/api/projects';
+import { ApiClient } from '../../../../services/api/client';
+
+// Mock navigation
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// Mock API client and service
+const mockCreateProject = vi.fn();
+
+vi.mock('../../../../services/api/client');
+vi.mock('../../../../services/api/projects');
+
+// Test helper to render component with context
+const renderWithContext = (ui: React.ReactElement) => {
+  return render(
+    <BrowserRouter>
+      <ProjectProvider>{ui}</ProjectProvider>
+    </BrowserRouter>
+  );
+};
+
+describe('CreateProjectForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockClear();
+    
+    // Mock ApiClient constructor
+    (ApiClient as any).mockImplementation(function(this: any) {
+      return {};
+    });
+    
+    // Mock ProjectsService constructor
+    (ProjectsService as any).mockImplementation(function(this: any) {
+      this.createProject = mockCreateProject;
+      return this;
+    });
+  });
+
+  describe('Initial Rendering', () => {
+    it('renders the form with header and note', () => {
+      renderWithContext(<CreateProjectForm />);
+      
+      expect(screen.getByText('Create New Project')).toBeInTheDocument();
+      expect(screen.getByText(/This is a quick-add form/i)).toBeInTheDocument();
+      expect(screen.getByText(/AI Chat workflow/i)).toBeInTheDocument();
+    });
+
+    it('renders step indicator with three steps', () => {
+      renderWithContext(<CreateProjectForm />);
+      
+      expect(screen.getByText('Basic Info')).toBeInTheDocument();
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+      expect(screen.getByText('Confirmation')).toBeInTheDocument();
+    });
+
+    it('starts on basic info step', () => {
+      renderWithContext(<CreateProjectForm />);
+      
+      expect(screen.getByText('Basic Information')).toBeInTheDocument();
+      expect(screen.getByLabelText(/Project Key/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Project Name/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Basic Info Step - Validation', () => {
+    it('shows error when project key is empty', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      const nextButton = screen.getByText('Next');
+      await user.click(nextButton);
+      
+      expect(screen.getByText('Project key is required')).toBeInTheDocument();
+    });
+
+    it('shows error when project key has invalid format', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      const keyInput = screen.getByLabelText(/Project Key/i);
+      // Type lowercase (will be converted to uppercase), then manually set invalid
+      await user.type(keyInput, '123');
+      
+      const nextButton = screen.getByText('Next');
+      await user.click(nextButton);
+      
+      expect(screen.getByText(/must start with uppercase letter/i)).toBeInTheDocument();
+    });
+
+    it('accepts valid project key format', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      const keyInput = screen.getByLabelText(/Project Key/i);
+      await user.type(keyInput, 'PROJ1');
+      
+      expect(keyInput).toHaveValue('PROJ1');
+    });
+
+    it('converts key input to uppercase', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      const keyInput = screen.getByLabelText(/Project Key/i);
+      await user.type(keyInput, 'proj1');
+      
+      expect(keyInput).toHaveValue('PROJ1');
+    });
+
+    it('shows error when project name is empty', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      const keyInput = screen.getByLabelText(/Project Key/i);
+      await user.type(keyInput, 'PROJ1');
+      
+      const nextButton = screen.getByText('Next');
+      await user.click(nextButton);
+      
+      expect(screen.getByText('Project name is required')).toBeInTheDocument();
+    });
+
+    it('shows error when project name is too short', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      const keyInput = screen.getByLabelText(/Project Key/i);
+      await user.type(keyInput, 'PROJ1');
+      
+      const nameInput = screen.getByLabelText(/Project Name/i);
+      await user.type(nameInput, 'AB');
+      
+      const nextButton = screen.getByText('Next');
+      await user.click(nextButton);
+      
+      expect(screen.getByText(/must be at least 3 characters/i)).toBeInTheDocument();
+    });
+
+    it('clears error when user corrects input', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      const nextButton = screen.getByText('Next');
+      await user.click(nextButton);
+      
+      expect(screen.getByText('Project key is required')).toBeInTheDocument();
+      
+      const keyInput = screen.getByLabelText(/Project Key/i);
+      await user.type(keyInput, 'PROJ1');
+      
+      expect(screen.queryByText('Project key is required')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Multi-Step Navigation', () => {
+    it('advances to settings step when basic info is valid', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      const keyInput = screen.getByLabelText(/Project Key/i);
+      await user.type(keyInput, 'PROJ1');
+      
+      const nameInput = screen.getByLabelText(/Project Name/i);
+      await user.type(nameInput, 'Test Project');
+      
+      const nextButton = screen.getByText('Next');
+      await user.click(nextButton);
+      
+      expect(screen.getByText('Project Settings')).toBeInTheDocument();
+      expect(screen.getByLabelText(/Description/i)).toBeInTheDocument();
+    });
+
+    it('advances to confirmation step from settings', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      // Fill basic info
+      await user.type(screen.getByLabelText(/Project Key/i), 'PROJ1');
+      await user.type(screen.getByLabelText(/Project Name/i), 'Test Project');
+      await user.click(screen.getByText('Next'));
+      
+      // Click next on settings
+      await user.click(screen.getByText('Next'));
+      
+      expect(screen.getByText('Review & Confirm')).toBeInTheDocument();
+      expect(screen.getByText('Project Key:')).toBeInTheDocument();
+    });
+
+    it('navigates back from settings to basic', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      // Go to settings
+      await user.type(screen.getByLabelText(/Project Key/i), 'PROJ1');
+      await user.type(screen.getByLabelText(/Project Name/i), 'Test Project');
+      await user.click(screen.getByText('Next'));
+      
+      // Click back
+      await user.click(screen.getByText('Back'));
+      
+      expect(screen.getByText('Basic Information')).toBeInTheDocument();
+    });
+
+    it('navigates back from confirmation to settings', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      // Go to confirmation
+      await user.type(screen.getByLabelText(/Project Key/i), 'PROJ1');
+      await user.type(screen.getByLabelText(/Project Name/i), 'Test Project');
+      await user.click(screen.getByText('Next'));
+      await user.click(screen.getByText('Next'));
+      
+      // Click back
+      await user.click(screen.getByText('Back'));
+      
+      expect(screen.getByText('Project Settings')).toBeInTheDocument();
+    });
+
+    it('preserves form data when navigating between steps', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      // Fill basic info
+      await user.type(screen.getByLabelText(/Project Key/i), 'PROJ1');
+      await user.type(screen.getByLabelText(/Project Name/i), 'Test Project');
+      await user.click(screen.getByText('Next'));
+      
+      // Add description
+      await user.type(screen.getByLabelText(/Description/i), 'Test description');
+      await user.click(screen.getByText('Next'));
+      
+      // Go back to basic
+      await user.click(screen.getByText('Back'));
+      await user.click(screen.getByText('Back'));
+      
+      // Verify data preserved
+      expect(screen.getByLabelText(/Project Key/i)).toHaveValue('PROJ1');
+      expect(screen.getByLabelText(/Project Name/i)).toHaveValue('Test Project');
+    });
+  });
+
+  describe('Settings Step', () => {
+    it('allows optional description', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      await user.type(screen.getByLabelText(/Project Key/i), 'PROJ1');
+      await user.type(screen.getByLabelText(/Project Name/i), 'Test Project');
+      await user.click(screen.getByText('Next'));
+      
+      const descriptionInput = screen.getByLabelText(/Description/i);
+      await user.type(descriptionInput, 'Optional description');
+      
+      expect(descriptionInput).toHaveValue('Optional description');
+    });
+
+    it('shows character count for description', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      await user.type(screen.getByLabelText(/Project Key/i), 'PROJ1');
+      await user.type(screen.getByLabelText(/Project Name/i), 'Test Project');
+      await user.click(screen.getByText('Next'));
+      
+      expect(screen.getByText('0/500 characters')).toBeInTheDocument();
+      
+      await user.type(screen.getByLabelText(/Description/i), 'Test');
+      
+      expect(screen.getByText('4/500 characters')).toBeInTheDocument();
+    });
+  });
+
+  describe('Confirmation Step', () => {
+    it('displays all entered information', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      await user.type(screen.getByLabelText(/Project Key/i), 'PROJ1');
+      await user.type(screen.getByLabelText(/Project Name/i), 'Test Project');
+      await user.click(screen.getByText('Next'));
+      
+      await user.type(screen.getByLabelText(/Description/i), 'Test description');
+      await user.click(screen.getByText('Next'));
+      
+      expect(screen.getByText('PROJ1')).toBeInTheDocument();
+      expect(screen.getByText('Test Project')).toBeInTheDocument();
+      expect(screen.getByText('Test description')).toBeInTheDocument();
+    });
+
+    it('shows placeholder when no description provided', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      await user.type(screen.getByLabelText(/Project Key/i), 'PROJ1');
+      await user.type(screen.getByLabelText(/Project Name/i), 'Test Project');
+      await user.click(screen.getByText('Next'));
+      await user.click(screen.getByText('Next'));
+      
+      expect(screen.getByText('No description provided')).toBeInTheDocument();
+    });
+  });
+
+  describe('Form Submission', () => {
+    it('creates project with correct data', async () => {
+      const user = userEvent.setup();
+      mockCreateProject.mockResolvedValue({
+        key: 'PROJ1',
+        name: 'Test Project',
+        description: 'Test description',
+        created_at: '2026-01-31T12:00:00Z',
+        updated_at: '2026-01-31T12:00:00Z',
+      });
+      
+      renderWithContext(<CreateProjectForm />);
+      
+      await user.type(screen.getByLabelText(/Project Key/i), 'PROJ1');
+      await user.type(screen.getByLabelText(/Project Name/i), 'Test Project');
+      await user.click(screen.getByText('Next'));
+      
+      await user.type(screen.getByLabelText(/Description/i), 'Test description');
+      await user.click(screen.getByText('Next'));
+      
+      await user.click(screen.getByText('Create Project'));
+      
+      await waitFor(() => {
+        expect(mockCreateProject).toHaveBeenCalledWith({
+          key: 'PROJ1',
+          name: 'Test Project',
+          description: 'Test description',
+        });
+      });
+    });
+
+    it('creates project without description', async () => {
+      const user = userEvent.setup();
+      mockCreateProject.mockResolvedValue({
+        key: 'PROJ1',
+        name: 'Test Project',
+        created_at: '2026-01-31T12:00:00Z',
+        updated_at: '2026-01-31T12:00:00Z',
+      });
+      
+      renderWithContext(<CreateProjectForm />);
+      
+      await user.type(screen.getByLabelText(/Project Key/i), 'PROJ1');
+      await user.type(screen.getByLabelText(/Project Name/i), 'Test Project');
+      await user.click(screen.getByText('Next'));
+      await user.click(screen.getByText('Next'));
+      
+      await user.click(screen.getByText('Create Project'));
+      
+      await waitFor(() => {
+        expect(mockCreateProject).toHaveBeenCalledWith({
+          key: 'PROJ1',
+          name: 'Test Project',
+          description: undefined,
+        });
+      });
+    });
+
+    it('navigates to project list after successful creation', async () => {
+      const user = userEvent.setup();
+      mockCreateProject.mockResolvedValue({
+        key: 'PROJ1',
+        name: 'Test Project',
+        created_at: '2026-01-31T12:00:00Z',
+        updated_at: '2026-01-31T12:00:00Z',
+      });
+      
+      renderWithContext(<CreateProjectForm />);
+      
+      await user.type(screen.getByLabelText(/Project Key/i), 'PROJ1');
+      await user.type(screen.getByLabelText(/Project Name/i), 'Test Project');
+      await user.click(screen.getByText('Next'));
+      await user.click(screen.getByText('Next'));
+      await user.click(screen.getByText('Create Project'));
+      
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/projects');
+      });
+    });
+
+    it('shows loading state during submission', async () => {
+      const user = userEvent.setup();
+      mockCreateProject.mockImplementation(
+        () => new Promise(resolve => setTimeout(resolve, 100))
+      );
+      
+      renderWithContext(<CreateProjectForm />);
+      
+      await user.type(screen.getByLabelText(/Project Key/i), 'PROJ1');
+      await user.type(screen.getByLabelText(/Project Name/i), 'Test Project');
+      await user.click(screen.getByText('Next'));
+      await user.click(screen.getByText('Next'));
+      await user.click(screen.getByText('Create Project'));
+      
+      expect(screen.getByText('Creating...')).toBeInTheDocument();
+      expect(screen.getByText('Back')).toBeDisabled();
+    });
+
+    it('displays error message on submission failure', async () => {
+      const user = userEvent.setup();
+      mockCreateProject.mockRejectedValue(new Error('Network error'));
+      
+      renderWithContext(<CreateProjectForm />);
+      
+      await user.type(screen.getByLabelText(/Project Key/i), 'PROJ1');
+      await user.type(screen.getByLabelText(/Project Name/i), 'Test Project');
+      await user.click(screen.getByText('Next'));
+      await user.click(screen.getByText('Next'));
+      await user.click(screen.getByText('Create Project'));
+      
+      await waitFor(() => {
+        expect(screen.getByText(/Network error/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Cancel Functionality', () => {
+    it('navigates to project list when cancel is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      await user.click(screen.getByText('Cancel'));
+      
+      expect(mockNavigate).toHaveBeenCalledWith('/projects');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has proper ARIA labels for inputs', () => {
+      renderWithContext(<CreateProjectForm />);
+      
+      expect(screen.getByLabelText(/Project Key/i)).toHaveAttribute('aria-invalid', 'false');
+      expect(screen.getByLabelText(/Project Name/i)).toHaveAttribute('aria-invalid', 'false');
+    });
+
+    it('sets aria-invalid when field has error', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      await user.click(screen.getByText('Next'));
+      
+      expect(screen.getByLabelText(/Project Key/i)).toHaveAttribute('aria-invalid', 'true');
+      expect(screen.getByLabelText(/Project Name/i)).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('links error messages with inputs via aria-describedby', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      await user.click(screen.getByText('Next'));
+      
+      const keyInput = screen.getByLabelText(/Project Key/i);
+      expect(keyInput).toHaveAttribute('aria-describedby', 'key-error');
+      expect(screen.getByText('Project key is required')).toHaveAttribute('id', 'key-error');
+    });
+
+    it('error messages have alert role', async () => {
+      const user = userEvent.setup();
+      renderWithContext(<CreateProjectForm />);
+      
+      await user.click(screen.getByText('Next'));
+      
+      const errorMessages = screen.getAllByRole('alert');
+      expect(errorMessages.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
# Summary
Implements a multi-step wizard form for quick project creation without AI chat guidance. Users can create simple projects by entering basic information (key, name, description) through a 3-step process with validation and confirmation.

## Goal / Acceptance Criteria (required)
- [x] Form wizard or stepper UI (3 steps: Basic Info → Settings → Confirmation)
- [x] Fields: Name, Key, Description (minimal required fields)
- [x] Project key validation (unique format: uppercase, letters, numbers, hyphens)
- [x] Auto-uppercase key input
- [x] Calls POST /projects endpoint via ProjectsService
- [x] Success: Redirect to project list (dashboard when #45 implemented)
- [x] Error handling with user feedback
- [x] Label: "Optional - Step 2 chat provides governance guidance"

## Issue / Tracking Link (required)
Fixes: #44

## Validation (required)

### Automated checks
- [x] Lint passes
- [x] Build passes
- [x] Tests pass (29 new tests, 447 total)

### Manual test evidence (required)
- [x] Manual test entry #1
  - Commands: `npm test -- --run` and `npm run build`
  - Evidence: 447/447 tests passing (29 new CreateProjectForm tests), build successful in 1.42s

## How to review
1. Check component implementation in `src/components/projects/CreateProjectForm.tsx`
2. Review CSS styling in `src/components/projects/CreateProjectForm.css`
3. Verify test coverage in `src/test/unit/components/projects/CreateProjectForm.test.tsx`
4. Run tests: `npm test -- --run src/test/unit/components/projects/CreateProjectForm.test.tsx`
5. Test locally: `npm run dev`, navigate to create project form
6. Verify multi-step navigation, validation, and form submission

## Cross-repo / Downstream impact (always include)
- Related repos/services impacted: None (UI only, uses existing ProjectsService)
