### PR TITLE
feat: ProposalList component with filtering and tests (Step 2.13)

### DIFF
--- a/client/src/components/ProposalList.css
+++ b/client/src/components/ProposalList.css
@@ -1,0 +1,158 @@
+/* ProposalList Styles */
+
+.proposal-list-container {
+  padding: 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.proposal-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.proposal-list-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: var(--text-primary, #1a1a1a);
+}
+
+.proposal-list-filters {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.proposal-list-filters label {
+  font-size: 0.9rem;
+  color: var(--text-secondary, #666);
+}
+
+.proposal-status-filter {
+  padding: 0.5rem;
+  border: 1px solid var(--border-color, #ddd);
+  border-radius: 4px;
+  font-size: 0.9rem;
+  background: white;
+  cursor: pointer;
+}
+
+.proposal-list-loading,
+.proposal-list-error {
+  text-align: center;
+  padding: 2rem;
+  color: var(--text-secondary, #666);
+}
+
+.proposal-list-error {
+  color: var(--error-color, #d32f2f);
+}
+
+.proposal-list-table-wrapper {
+  overflow-x: auto;
+  border: 1px solid var(--border-color, #e0e0e0);
+  border-radius: 8px;
+  background: white;
+}
+
+.proposal-list-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.proposal-list-table thead {
+  background: var(--table-header-bg, #f5f5f5);
+  border-bottom: 2px solid var(--border-color, #e0e0e0);
+}
+
+.proposal-list-table th {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font-weight: 600;
+  color: var(--text-primary, #1a1a1a);
+}
+
+.proposal-list-table td {
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--border-color, #e0e0e0);
+}
+
+.proposal-list-table tbody tr:hover {
+  background: var(--row-hover-bg, #f9f9f9);
+}
+
+.proposal-id {
+  font-family: 'Monaco', 'Courier New', monospace;
+  font-size: 0.85rem;
+  color: var(--text-secondary, #666);
+}
+
+.proposal-target {
+  font-weight: 500;
+  color: var(--text-primary, #1a1a1a);
+}
+
+.proposal-date {
+  color: var(--text-secondary, #666);
+  white-space: nowrap;
+}
+
+.proposal-author {
+  color: var(--text-secondary, #666);
+}
+
+.proposal-status-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.proposal-status-pending {
+  background: #fff3cd;
+  color: #856404;
+}
+
+.proposal-status-accepted {
+  background: #d4edda;
+  color: #155724;
+}
+
+.proposal-status-rejected {
+  background: #f8d7da;
+  color: #721c24;
+}
+
+.proposal-view-link {
+  color: var(--link-color, #1976d2);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.proposal-view-link:hover {
+  text-decoration: underline;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+  .proposal-list-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .proposal-list-table {
+    font-size: 0.85rem;
+  }
+
+  .proposal-list-table th,
+  .proposal-list-table td {
+    padding: 0.5rem 0.75rem;
+  }
+}

--- a/client/src/components/ProposalList.tsx
+++ b/client/src/components/ProposalList.tsx
@@ -1,0 +1,182 @@
+/**
+ * ProposalList Component
+ * Displays list of proposals with filtering and navigation to review
+ */
+
+import { useState, useEffect } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import {
+  proposalApiClient,
+  type ProposalStatus,
+  type Proposal,
+} from '../services/ProposalApiClient';
+import EmptyState from './ui/EmptyState';
+import { Button } from './ui/Button';
+import './ProposalList.css';
+
+interface ProposalListProps {
+  projectKey: string;
+}
+
+export default function ProposalList({ projectKey }: ProposalListProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Get status filter from URL, default to 'pending'
+  const statusFilter =
+    (searchParams.get('status') as ProposalStatus) || 'pending';
+
+  useEffect(() => {
+    loadProposals();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectKey, statusFilter]);
+
+  const loadProposals = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await proposalApiClient.listProposals(
+        projectKey,
+        statusFilter,
+      );
+      // Sort by date (newest first)
+      const sorted = data.sort(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      );
+      setProposals(sorted);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load proposals');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleFilterChange = (status: ProposalStatus) => {
+    setSearchParams({ status });
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const getStatusBadgeClass = (status: ProposalStatus): string => {
+    switch (status) {
+      case 'pending':
+        return 'proposal-status-badge proposal-status-pending';
+      case 'accepted':
+        return 'proposal-status-badge proposal-status-accepted';
+      case 'rejected':
+        return 'proposal-status-badge proposal-status-rejected';
+      default:
+        return 'proposal-status-badge';
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="proposal-list-container">
+        <div className="proposal-list-header">
+          <h2>Proposals</h2>
+        </div>
+        <div className="proposal-list-loading">Loading proposals...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="proposal-list-container">
+        <div className="proposal-list-header">
+          <h2>Proposals</h2>
+        </div>
+        <div className="proposal-list-error" role="alert">
+          Error: {error}
+        </div>
+        <Button onClick={loadProposals}>Retry</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="proposal-list-container">
+      <div className="proposal-list-header">
+        <h2>Proposals</h2>
+        <div className="proposal-list-filters">
+          <label htmlFor="status-filter">Filter by status:</label>
+          <select
+            id="status-filter"
+            value={statusFilter}
+            onChange={(e) =>
+              handleFilterChange(e.target.value as ProposalStatus)
+            }
+            className="proposal-status-filter"
+          >
+            <option value="pending">Pending</option>
+            <option value="accepted">Accepted</option>
+            <option value="rejected">Rejected</option>
+          </select>
+        </div>
+      </div>
+
+      {proposals.length === 0 ? (
+        <EmptyState
+          icon="📝"
+          title="No proposals found"
+          description={`No ${statusFilter} proposals for this project.`}
+        />
+      ) : (
+        <div className="proposal-list-table-wrapper">
+          <table className="proposal-list-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Target Artifact</th>
+                <th>Status</th>
+                <th>Created</th>
+                <th>Author</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {proposals.map((proposal) => (
+                <tr key={proposal.id}>
+                  <td className="proposal-id">{proposal.id}</td>
+                  <td className="proposal-target">
+                    {proposal.target_artifact}
+                  </td>
+                  <td>
+                    <span className={getStatusBadgeClass(proposal.status)}>
+                      {proposal.status}
+                    </span>
+                  </td>
+                  <td className="proposal-date">
+                    {formatDate(proposal.created_at)}
+                  </td>
+                  <td className="proposal-author">{proposal.author}</td>
+                  <td>
+                    <Link
+                      to={`/projects/${projectKey}/proposals/${proposal.id}`}
+                      className="proposal-view-link"
+                    >
+                      View
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/__tests__/ProposalList.test.tsx
+++ b/client/src/components/__tests__/ProposalList.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * ProposalList Component Tests
+ */
+
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import ProposalList from '../ProposalList';
+import {
+  proposalApiClient,
+  type Proposal,
+} from '../../services/ProposalApiClient';
+
+// Mock the ProposalApiClient
+vi.mock('../../services/ProposalApiClient', () => ({
+  proposalApiClient: {
+    listProposals: vi.fn(),
+  },
+  ProposalStatus: {
+    PENDING: 'pending',
+    ACCEPTED: 'accepted',
+    REJECTED: 'rejected',
+  },
+}));
+
+const mockProposals: Proposal[] = [
+  {
+    id: 'prop-001',
+    project_key: 'TEST',
+    target_artifact: 'docs/README.md',
+    change_type: 'update',
+    diff: '--- a/docs/README.md\n+++ b/docs/README.md\n@@ -1,1 +1,1 @@\n-Old content\n+New content',
+    rationale: 'Update documentation',
+    status: 'pending',
+    author: 'Alice',
+    created_at: '2026-02-01T10:00:00Z',
+  },
+  {
+    id: 'prop-002',
+    project_key: 'TEST',
+    target_artifact: 'docs/CONTRIBUTING.md',
+    change_type: 'create',
+    diff: '--- /dev/null\n+++ b/docs/CONTRIBUTING.md\n@@ -0,0 +1,1 @@\n+New file',
+    rationale: 'Add contributing guide',
+    status: 'pending',
+    author: 'Bob',
+    created_at: '2026-02-01T09:00:00Z',
+  },
+  {
+    id: 'prop-003',
+    project_key: 'TEST',
+    target_artifact: 'docs/CHANGELOG.md',
+    change_type: 'update',
+    diff: '--- a/docs/CHANGELOG.md\n+++ b/docs/CHANGELOG.md\n@@ -1,1 +1,2 @@\n Version 1.0\n+Version 1.1',
+    rationale: 'Update changelog',
+    status: 'accepted',
+    author: 'Charlie',
+    created_at: '2026-01-31T15:00:00Z',
+  },
+];
+
+describe('ProposalList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderComponent = (projectKey = 'TEST') => {
+    return render(
+      <MemoryRouter>
+        <ProposalList projectKey={projectKey} />
+      </MemoryRouter>,
+    );
+  };
+
+  it('should render loading state initially', () => {
+    vi.mocked(proposalApiClient.listProposals).mockImplementation(
+      () => new Promise(() => {}), // Never resolves
+    );
+
+    renderComponent();
+    expect(screen.getByText(/loading proposals/i)).toBeInTheDocument();
+  });
+
+  it('should fetch and display proposals', async () => {
+    vi.mocked(proposalApiClient.listProposals).mockResolvedValue(
+      mockProposals.filter((p) => p.status === 'pending'),
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('prop-001')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('docs/README.md')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('prop-002')).toBeInTheDocument();
+  });
+
+  it('should display proposals sorted by date (newest first)', async () => {
+    vi.mocked(proposalApiClient.listProposals).mockResolvedValue(
+      mockProposals.filter((p) => p.status === 'pending'),
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('prop-001')).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByRole('row');
+    // Skip header row
+    const dataRows = rows.slice(1);
+
+    // prop-001 (10:00) should come before prop-002 (09:00)
+    expect(within(dataRows[0]).getByText('prop-001')).toBeInTheDocument();
+    expect(within(dataRows[1]).getByText('prop-002')).toBeInTheDocument();
+  });
+
+  it('should filter proposals by status', async () => {
+    const user = userEvent.setup();
+
+    // Initially load pending proposals
+    vi.mocked(proposalApiClient.listProposals).mockResolvedValue(
+      mockProposals.filter((p) => p.status === 'pending'),
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('prop-001')).toBeInTheDocument();
+    });
+
+    // Change filter to accepted
+    vi.mocked(proposalApiClient.listProposals).mockResolvedValue(
+      mockProposals.filter((p) => p.status === 'accepted'),
+    );
+
+    const filterSelect = screen.getByLabelText(/filter by status/i);
+    await user.selectOptions(filterSelect, 'accepted');
+
+    await waitFor(() => {
+      expect(proposalApiClient.listProposals).toHaveBeenCalledWith(
+        'TEST',
+        'accepted',
+      );
+    });
+  });
+
+  it('should display empty state when no proposals', async () => {
+    vi.mocked(proposalApiClient.listProposals).mockResolvedValue([]);
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/no proposals found/i)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/no pending proposals for this project/i),
+    ).toBeInTheDocument();
+  });
+
+  it('should display error state on API failure', async () => {
+    vi.mocked(proposalApiClient.listProposals).mockRejectedValue(
+      new Error('Network error'),
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/error: network error/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('should render status badges with correct styles', async () => {
+    const mixedProposals = [
+      { ...mockProposals[0], status: 'pending' as const },
+      { ...mockProposals[1], status: 'accepted' as const },
+      { ...mockProposals[2], status: 'rejected' as const },
+    ];
+
+    vi.mocked(proposalApiClient.listProposals).mockResolvedValue(
+      mixedProposals,
+    );
+
+    // Render with no default filter to show all
+    render(
+      <MemoryRouter initialEntries={['?status=']}>
+        <ProposalList projectKey="TEST" />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      const badges = screen.getAllByText(/pending|accepted|rejected/i);
+      expect(badges.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('should render view links for each proposal', async () => {
+    vi.mocked(proposalApiClient.listProposals).mockResolvedValue(
+      mockProposals.filter((p) => p.status === 'pending'),
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      const viewLinks = screen.getAllByText(/view/i);
+      expect(viewLinks).toHaveLength(2); // Two pending proposals
+    });
+
+    const viewLinks = screen.getAllByText(/view/i);
+    expect(viewLinks[0]).toHaveAttribute(
+      'href',
+      '/projects/TEST/proposals/prop-001',
+    );
+  });
+
+  it('should retry loading on button click', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(proposalApiClient.listProposals).mockRejectedValueOnce(
+      new Error('First attempt failed'),
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/error: first attempt failed/i),
+      ).toBeInTheDocument();
+    });
+
+    // Mock successful retry
+    vi.mocked(proposalApiClient.listProposals).mockResolvedValue(
+      mockProposals.filter((p) => p.status === 'pending'),
+    );
+
+    const retryButton = screen.getByRole('button', { name: /retry/i });
+    await user.click(retryButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('prop-001')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
# Summary
Implements ProposalList component with filtering and navigation to proposal review interface (Step 2.13). Users can browse pending/accepted/rejected proposals and click through to review details.

## Goal / Acceptance Criteria (required)
- [x] `ProposalList` fetches and displays proposals
- [x] Status filter works (pending, accepted, rejected)
- [x] Clicking proposal opens review interface
- [x] Empty state shown when no proposals
- [x] Sort works (by date, newest first)
- [x] Unit tests pass (9 tests, all passing)
- [x] Build passes

## Issue / Tracking Link (required)
Fixes: #105

## Validation (required)

### Automated checks
- [x] Lint passes
  - Command(s): No lint script in this repo (package.json only has dev, build, preview, test scripts)
  - Evidence: N/A - repo does not have lint script configured
- [x] Tests pass
  - Command(s): `cd client && npm test -- --run ProposalList`
  - Evidence: 9 tests passed in 1.57s (all ProposalList tests)
- [x] Build passes
  - Command(s): `cd client && npm run build`
  - Evidence: `tsc && vite build` completed in 1.59s, dist/assets/index.js 271.13 kB

### Manual test evidence (required)
- [x] Manual test entry #1: ProposalList tests passing
  - Command: `npm test -- --run ProposalList`
  - Evidence: 9/9 tests passing
  - Output: Tests cover loading state, proposal display, filtering, sorting, empty states, error handling, status badges, navigation links, retry functionality

- [x] Manual test entry #2: Test isolation fixed
  - Command: `npm test -- --run -t "should display empty state when no proposals"`
  - Evidence: Changed from BrowserRouter to MemoryRouter to prevent test pollution
  - Output: Test passes in isolation and when run with full suite

- [x] Manual test entry #3: TypeScript compilation
  - Command: `npm run build`
  - Evidence: Build succeeds with no TypeScript errors
  - Output: Production build 271.13 kB (gzipped: 88.44 kB)

## How to review

1. **Component**: [ProposalList.tsx](client/src/components/ProposalList.tsx) implements list view with filtering by status (pending/accepted/rejected), sorting by date, and navigation to proposal detail view
2. **Styling**: [ProposalList.css](client/src/components/ProposalList.css) provides table layout with color-coded status badges (yellow=pending, green=accepted, red=rejected)
3. **Unit Tests**: [ProposalList.test.tsx](client/src/components/__tests__/ProposalList.test.tsx) provides comprehensive coverage with 9 tests using MemoryRouter for proper test isolation
4. **API Integration**: Component uses existing ProposalApiClient singleton for fetching proposals from `/api/v1/projects/{key}/proposals`
5. **Routing**: App.tsx already has route `/projects/:projectKey/proposals` configured (wrapper component ProposalListWrapper passes projectKey prop)

## Cross-repo / Downstream impact (always include)
- Related repos/services impacted: Backend proposals API (GET /api/v1/projects/{key}/proposals) already implemented in backend repo
- No breaking changes: Additive only, component and tests added
- Backend coordination: Backend proposals endpoint exists with status filtering support
- Future work: Implement ProposalReview component for detailed proposal view (currently shows placeholder "Proposal Review (TBD)")
