### PR TITLE
fix: standardize route params to projectKey (issue #151)

### DIFF
--- a/client/src/components/ProjectView.tsx
+++ b/client/src/components/ProjectView.tsx
@@ -17,8 +17,7 @@ type TabType = 'overview' | 'propose' | 'apply' | 'commands' | 'artifacts' | 'au
 
 export default function ProjectView() {
   const { t } = useTranslation();
-  const params = useParams<{ projectKey?: string; key?: string }>();
-  const projectKey = params.projectKey ?? params.key;
+  const { projectKey } = useParams<{ projectKey: string }>();
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<TabType>('overview');
 

--- a/client/src/components/__tests__/ProjectView.test.tsx
+++ b/client/src/components/__tests__/ProjectView.test.tsx
@@ -72,7 +72,7 @@ function renderWithProviders(ui: React.ReactElement, { route = '/projects/TEST-1
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={[route]}>
           <Routes>
-            <Route path="/projects/:key" element={ui} />
+            <Route path="/projects/:projectKey" element={ui} />
           </Routes>
         </MemoryRouter>
       </QueryClientProvider>


### PR DESCRIPTION
# Summary

Fix route parameter inconsistency by standardizing ProjectView route param handling to `projectKey` only and aligning tests with the same route pattern.

## Goal / Acceptance Criteria (required)

**Goal:** Ensure route parameter naming is consistent (`projectKey`) to avoid navigation/param ambiguity.

**Acceptance Criteria:**

- [x] All routes use `projectKey` (not `key`) in implementation scope
- [x] Route definitions in App.tsx already use `projectKey`
- [x] ProjectView uses `useParams<{ projectKey: string }>()`
- [x] ProjectView tests use `/projects/:projectKey`
- [x] Navigation from ProjectList → ProjectView remains functional
- [x] No 404/param mismatch regressions introduced
- [x] Lint passes: `npm run lint` (warnings only)
- [x] Build passes: `npm run build`
- [x] Tests pass: `npm test -- --run`

## Issue / Tracking Link (required)

Fixes: #151

## Validation (required)

### Automated checks

- [x] Lint passes
  - Command(s): `cd client && npm run lint`
  - Evidence: 0 errors, 7 warnings (pre-existing)

- [x] Build passes
  - Command(s): `cd client && npm run build`
  - Evidence: `✓ built in 2.78s`

- [x] Tests pass
  - Command(s): `cd client && npm test -- --run`
  - Evidence: `58 passed`, `788 passed | 5 skipped`

### Manual test evidence (required)

- [x] Manual test entry #1
  - Scenario: Load ProjectView via `/projects/{projectKey}`
  - Expected result: Project loads correctly and tabs render
  - Actual result / Evidence: ProjectView param binding works using `projectKey`

- [x] Manual test entry #2
  - Scenario: Execute ProjectView test suite
  - Expected result: tests pass with `/projects/:projectKey` route pattern
  - Actual result / Evidence: `src/components/__tests__/ProjectView.test.tsx` passes in full test run

## How to review

1. Inspect `client/src/components/ProjectView.tsx` for `useParams<{ projectKey: string }>()`.
2. Inspect `client/src/components/__tests__/ProjectView.test.tsx` route definition.
3. Confirm no legacy `:key` route usage remains in changed scope.
4. Run validation commands listed above.

## Cross-repo / Downstream impact (always include)

- Related repos/services impacted: None (client-only)
- Backend/API contract changes: None
- Deployment impact: None
