### PR TITLE
feat: Create Sync Panel & Conflict Resolver UI (Phase 2.2)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,7 @@ import ErrorBoundary from './components/ErrorBoundary';
 import LanguageSwitcher from './components/LanguageSwitcher';
 import ConnectionStatus from './components/ConnectionStatus';
 import ConnectionBanner from './components/ConnectionBanner';
+import SyncPanel from './components/SyncPanel';
 import { useConnection } from './hooks/useConnection';
 import { ProjectsStateProvider } from './state/projectsState';
 import { RaidStateProvider } from './state/raidState';
@@ -154,6 +155,14 @@ function App() {
                             element={
                               <ErrorBoundary name="ProjectView">
                                 <ProjectView />
+                              </ErrorBoundary>
+                            }
+                          />
+                          <Route
+                            path="/projects/:projectKey/sync"
+                            element={
+                              <ErrorBoundary name="SyncPanel">
+                                <SyncPanel />
                               </ErrorBoundary>
                             }
                           />

--- a/client/src/components/ConflictResolver.css
+++ b/client/src/components/ConflictResolver.css
@@ -1,0 +1,44 @@
+.conflict-resolver {
+  margin-top: 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fff;
+  padding: 1rem;
+}
+
+.conflict-resolver h3 {
+  margin: 0 0 0.75rem;
+}
+
+.conflict-options {
+  margin: 1rem 0;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.conflict-options legend {
+  font-weight: 600;
+  padding: 0 0.25rem;
+}
+
+.conflict-options label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.conflict-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+@media (max-width: 768px) {
+  .conflict-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/client/src/components/ConflictResolver.tsx
+++ b/client/src/components/ConflictResolver.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { DiffViewer } from './DiffViewer';
+import type { ConflictResolution, SyncConflict } from '../types/sync';
+import './ConflictResolver.css';
+
+interface ConflictResolverProps {
+  conflict: SyncConflict;
+  onResolve: (resolution: ConflictResolution) => void;
+  onCancel: () => void;
+}
+
+export default function ConflictResolver({
+  conflict,
+  onResolve,
+  onCancel,
+}: ConflictResolverProps) {
+  const { t } = useTranslation();
+  const [selectedResolution, setSelectedResolution] =
+    useState<ConflictResolution>('mine');
+
+  return (
+    <section className="conflict-resolver" aria-label={t('sync.conflict.title', { file: conflict.file })}>
+      <h3>{t('sync.conflict.title', { file: conflict.file })}</h3>
+
+      <DiffViewer
+        oldContent={conflict.localContent}
+        newContent={conflict.remoteContent}
+        splitView
+        fileName={conflict.file}
+      />
+
+      <fieldset className="conflict-options">
+        <legend>{t('sync.conflict.resolutionOptions')}</legend>
+
+        <label>
+          <input
+            type="radio"
+            name="resolution"
+            value="mine"
+            checked={selectedResolution === 'mine'}
+            onChange={() => setSelectedResolution('mine')}
+          />
+          {t('sync.conflict.keepMine')}
+        </label>
+
+        <label>
+          <input
+            type="radio"
+            name="resolution"
+            value="theirs"
+            checked={selectedResolution === 'theirs'}
+            onChange={() => setSelectedResolution('theirs')}
+          />
+          {t('sync.conflict.useTheirs')}
+        </label>
+
+        <label>
+          <input
+            type="radio"
+            name="resolution"
+            value="ai"
+            checked={selectedResolution === 'ai'}
+            onChange={() => setSelectedResolution('ai')}
+          />
+          {t('sync.conflict.aiSuggestion')}
+        </label>
+
+        <label>
+          <input
+            type="radio"
+            name="resolution"
+            value="manual"
+            checked={selectedResolution === 'manual'}
+            onChange={() => setSelectedResolution('manual')}
+          />
+          {t('sync.conflict.manual')}
+        </label>
+      </fieldset>
+
+      <div className="conflict-actions">
+        <button type="button" className="btn-secondary" onClick={onCancel}>
+          {t('sync.conflict.cancel')}
+        </button>
+        <button type="button" className="btn-primary" onClick={() => onResolve(selectedResolution)}>
+          {t('sync.conflict.apply')}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/SyncHistory.css
+++ b/client/src/components/SyncHistory.css
@@ -1,0 +1,52 @@
+.sync-history {
+  margin-top: 1rem;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+.sync-history h4 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.sync-history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.sync-history-item {
+  border: 1px solid #f0f0f0;
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+}
+
+.sync-history-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
+
+.sync-history-state {
+  display: inline-flex;
+  font-weight: 600;
+}
+
+.sync-history-item p {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+  .sync-history-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/client/src/components/SyncHistory.tsx
+++ b/client/src/components/SyncHistory.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from 'react-i18next';
+import type { SyncEvent } from '../types/sync';
+import './SyncHistory.css';
+
+interface SyncHistoryProps {
+  events: SyncEvent[];
+}
+
+export default function SyncHistory({ events }: SyncHistoryProps) {
+  const { t } = useTranslation();
+  const visibleEvents = events.slice(0, 10);
+
+  return (
+    <section className="sync-history" aria-label={t('sync.history.title')}>
+      <h4>{t('sync.history.title')}</h4>
+      <ul className="sync-history-list">
+        {visibleEvents.map((event) => (
+          <li key={event.id} className="sync-history-item">
+            <div className="sync-history-row">
+              <span className={`sync-history-state sync-history-state--${event.state}`}>
+                {t(`sync.state.${event.state}`)}
+              </span>
+              <time dateTime={event.timestamp.toISOString()}>
+                {event.timestamp.toLocaleString()}
+              </time>
+            </div>
+            <p>{t(event.message)}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/client/src/components/SyncPanel.css
+++ b/client/src/components/SyncPanel.css
@@ -1,0 +1,119 @@
+.sync-page {
+  max-width: 1000px;
+  margin: 1.25rem auto;
+  padding: 0 1rem 1.5rem;
+}
+
+.sync-panel {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  padding: 1rem;
+}
+
+.sync-panel-header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.sync-panel-icon {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  background: #eef2ff;
+  color: #1f2937;
+}
+
+.sync-panel h2 {
+  margin: 0;
+}
+
+.sync-panel-state {
+  margin: 0.25rem 0 0;
+  font-weight: 600;
+}
+
+.sync-panel-description {
+  margin: 0.75rem 0;
+  color: #4b5563;
+}
+
+.sync-panel-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.btn-primary,
+.btn-secondary {
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  padding: 0.5rem 0.8rem;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: #4f46e5;
+  color: #fff;
+  border-color: #4f46e5;
+}
+
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: #fff;
+  color: #1f2937;
+}
+
+.sync-demo {
+  margin-top: 1rem;
+  border-top: 1px dashed #e5e7eb;
+  padding-top: 0.75rem;
+}
+
+.sync-demo-states {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.sync-demo-chip {
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  border-radius: 999px;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.sync-demo-chip.active {
+  border-color: #4f46e5;
+  color: #4f46e5;
+}
+
+.sync-feedback {
+  margin-top: 0.75rem;
+  color: #065f46;
+  font-weight: 500;
+}
+
+@media (max-width: 768px) {
+  .sync-panel-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sync-demo-states {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+}

--- a/client/src/components/SyncPanel.tsx
+++ b/client/src/components/SyncPanel.tsx
@@ -1,0 +1,121 @@
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useState } from 'react';
+import { useSyncStatus } from '../hooks/useSyncStatus';
+import type { ConflictResolution, SyncState } from '../types/sync';
+import ConflictResolver from './ConflictResolver';
+import SyncHistory from './SyncHistory';
+import './SyncPanel.css';
+
+const ICON_BY_STATE: Record<SyncState, string> = {
+  clean: '✓',
+  ahead: '↑',
+  behind: '↓',
+  diverged: '↕',
+  running: '⟳',
+  failed: '✗',
+  conflict: '⚠',
+};
+
+export default function SyncPanel() {
+  const { t } = useTranslation();
+  const { projectKey } = useParams<{ projectKey: string }>();
+  const { status, conflicts, events, availableStates, setDemoState } =
+    useSyncStatus(projectKey);
+  const [resolutionMessage, setResolutionMessage] = useState<string | null>(null);
+
+  const getDescription = () => {
+    switch (status.state) {
+      case 'ahead':
+        return t('sync.description.ahead', { count: status.localCommits });
+      case 'behind':
+        return t('sync.description.behind', { count: status.remoteCommits });
+      case 'diverged':
+        return t('sync.description.diverged', {
+          local: status.localCommits,
+          remote: status.remoteCommits,
+        });
+      case 'running':
+        return t('sync.description.running');
+      case 'failed':
+        return t('sync.description.failed', {
+          error: status.error ?? t('sync.error.unknown'),
+        });
+      case 'conflict':
+        return t('sync.description.conflict');
+      case 'clean':
+      default:
+        return t('sync.description.clean');
+    }
+  };
+
+  const handleSyncNow = () => {
+    // TODO: Replace with API call to /projects/:projectKey/sync/status
+    setResolutionMessage(t('sync.feedback.syncRequested'));
+  };
+
+  const handleResolve = (resolution: ConflictResolution) => {
+    // TODO: Replace with API call to /projects/:projectKey/sync/resolve
+    setResolutionMessage(t('sync.feedback.resolved', { resolution: t(`sync.conflict.${resolution}`) }));
+  };
+
+  return (
+    <div className="sync-page" data-testid="sync-panel">
+      <section className={`sync-panel sync-panel--${status.state}`}>
+        <header className="sync-panel-header">
+          <span className="sync-panel-icon" aria-hidden="true">
+            {ICON_BY_STATE[status.state]}
+          </span>
+          <div>
+            <h2>{t('sync.title')}</h2>
+            <p className="sync-panel-state">{t(`sync.state.${status.state}`)}</p>
+          </div>
+        </header>
+
+        <p className="sync-panel-description">{getDescription()}</p>
+
+        <div className="sync-panel-actions">
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={handleSyncNow}
+            disabled={status.state === 'running'}
+          >
+            {t('sync.action.syncNow')}
+          </button>
+          <button type="button" className="btn-secondary">
+            {t('sync.action.viewHistory')}
+          </button>
+        </div>
+
+        <div className="sync-demo" aria-label={t('sync.demo.title')}>
+          <strong>{t('sync.demo.title')}</strong>
+          <div className="sync-demo-states">
+            {availableStates.map((state) => (
+              <button
+                type="button"
+                key={state}
+                className={`sync-demo-chip ${state === status.state ? 'active' : ''}`}
+                onClick={() => setDemoState(state)}
+              >
+                {ICON_BY_STATE[state]} {t(`sync.state.${state}`)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {resolutionMessage && <p className="sync-feedback">{resolutionMessage}</p>}
+      </section>
+
+      {status.state === 'conflict' && conflicts[0] && (
+        <ConflictResolver
+          conflict={conflicts[0]}
+          onResolve={handleResolve}
+          onCancel={() => setResolutionMessage(null)}
+        />
+      )}
+
+      <SyncHistory events={events} />
+    </div>
+  );
+}

--- a/client/src/hooks/useSyncStatus.ts
+++ b/client/src/hooks/useSyncStatus.ts
@@ -1,0 +1,90 @@
+import { useMemo, useState } from 'react';
+import type {
+  SyncConflict,
+  SyncEvent,
+  SyncState,
+  SyncStatus,
+} from '../types/sync';
+
+const SYNC_STATES: SyncState[] = [
+  'clean',
+  'ahead',
+  'behind',
+  'diverged',
+  'running',
+  'failed',
+  'conflict',
+];
+
+const MOCK_BY_STATE: Record<SyncState, SyncStatus> = {
+  clean: { state: 'clean', localCommits: 0, remoteCommits: 0, lastSync: new Date() },
+  ahead: { state: 'ahead', localCommits: 2, remoteCommits: 0, lastSync: new Date() },
+  behind: { state: 'behind', localCommits: 0, remoteCommits: 3, lastSync: new Date() },
+  diverged: { state: 'diverged', localCommits: 2, remoteCommits: 1, lastSync: new Date() },
+  running: { state: 'running', localCommits: 0, remoteCommits: 0, lastSync: new Date() },
+  failed: {
+    state: 'failed',
+    localCommits: 1,
+    remoteCommits: 1,
+    lastSync: new Date(),
+    error: 'Network timeout while syncing',
+  },
+  conflict: { state: 'conflict', localCommits: 1, remoteCommits: 1, lastSync: new Date() },
+};
+
+const MOCK_CONFLICTS: SyncConflict[] = [
+  {
+    file: 'project-charter.md',
+    localContent: '## Project Charter\n\nLocal goal update\nOwner: Alice',
+    remoteContent: '## Project Charter\n\nRemote scope update\nOwner: Bob',
+  },
+  {
+    file: 'risk-register.md',
+    localContent: '## Risks\n\n- Budget variance',
+    remoteContent: '## Risks\n\n- Schedule delay',
+  },
+];
+
+const MOCK_EVENTS: SyncEvent[] = [
+  { id: '1', timestamp: new Date(Date.now() - 10 * 60 * 1000), state: 'clean', message: 'sync.history.synced' },
+  { id: '2', timestamp: new Date(Date.now() - 25 * 60 * 1000), state: 'ahead', message: 'sync.history.localChanges' },
+  { id: '3', timestamp: new Date(Date.now() - 40 * 60 * 1000), state: 'running', message: 'sync.history.started' },
+  { id: '4', timestamp: new Date(Date.now() - 65 * 60 * 1000), state: 'failed', message: 'sync.history.failed' },
+  { id: '5', timestamp: new Date(Date.now() - 95 * 60 * 1000), state: 'conflict', message: 'sync.history.conflictDetected' },
+  { id: '6', timestamp: new Date(Date.now() - 140 * 60 * 1000), state: 'behind', message: 'sync.history.remoteChanges' },
+  { id: '7', timestamp: new Date(Date.now() - 3 * 60 * 60 * 1000), state: 'diverged', message: 'sync.history.diverged' },
+];
+
+interface UseSyncStatusResult {
+  status: SyncStatus;
+  conflicts: SyncConflict[];
+  events: SyncEvent[];
+  availableStates: SyncState[];
+  setDemoState: (state: SyncState) => void;
+}
+
+export function useSyncStatus(projectKey?: string): UseSyncStatusResult {
+  const [demoState, setDemoState] = useState<SyncState | null>(null);
+
+  const seededState = useMemo<SyncState>(() => {
+    if (!projectKey) {
+      return 'clean';
+    }
+
+    const seed = projectKey
+      .split('')
+      .reduce((acc, char) => acc + char.charCodeAt(0), 0);
+    return SYNC_STATES[seed % SYNC_STATES.length];
+  }, [projectKey]);
+
+  const effectiveState = demoState ?? seededState;
+  const status = MOCK_BY_STATE[effectiveState];
+
+  return {
+    status,
+    conflicts: effectiveState === 'conflict' ? MOCK_CONFLICTS : [],
+    events: MOCK_EVENTS.slice(0, 7),
+    availableStates: SYNC_STATES,
+    setDemoState,
+  };
+}

--- a/client/src/i18n/i18n.de.json
+++ b/client/src/i18n/i18n.de.json
@@ -251,12 +251,60 @@
   },
   "sync": {
     "title": "Sync",
-    "cta": {
-      "start": "Sync starten",
-      "openConflicts": "Konflikte öffnen"
-    },
     "state": {
+      "clean": "Synchron",
+      "ahead": "Voraus",
+      "behind": "Zurück",
+      "diverged": "Auseinandergelaufen",
+      "running": "Synchronisiere…",
+      "failed": "Synchronisierung fehlgeschlagen",
       "conflict": "Konflikt"
+    },
+    "description": {
+      "clean": "Keine ausstehenden Änderungen. Alles ist aktuell.",
+      "ahead": "Sie haben {{count}} lokale Änderung(en), die noch nicht synchronisiert wurden.",
+      "behind": "Es gibt {{count}} entfernte Änderung(en), die noch übernommen werden müssen.",
+      "diverged": "Lokale ({{local}}) und entfernte ({{remote}}) Änderungen liegen gleichzeitig vor.",
+      "running": "Synchronisierung läuft gerade. Bitte warten...",
+      "failed": "Synchronisierung fehlgeschlagen: {{error}}",
+      "conflict": "Konflikte erfordern eine manuelle Auflösung, bevor die Synchronisierung abgeschlossen werden kann."
+    },
+    "action": {
+      "syncNow": "Jetzt synchronisieren",
+      "viewHistory": "Verlauf anzeigen"
+    },
+    "conflict": {
+      "title": "Konflikt lösen: {{file}}",
+      "resolutionOptions": "Auflösungsoptionen",
+      "keepMine": "Meine Version behalten",
+      "useTheirs": "Remote-Version verwenden",
+      "aiSuggestion": "KI-Vorschlag",
+      "manual": "Manuell bearbeiten",
+      "mine": "Meine Version behalten",
+      "theirs": "Remote-Version verwenden",
+      "ai": "KI-Vorschlag",
+      "cancel": "Abbrechen",
+      "apply": "Auflösung anwenden"
+    },
+    "history": {
+      "title": "Synchronisierungsverlauf",
+      "synced": "Synchronisierung erfolgreich abgeschlossen.",
+      "localChanges": "Lokale Änderungen erkannt.",
+      "started": "Synchronisierung gestartet.",
+      "failed": "Synchronisierung fehlgeschlagen.",
+      "conflictDetected": "Konflikt während der Synchronisierung erkannt.",
+      "remoteChanges": "Remote-Änderungen erkannt.",
+      "diverged": "Lokaler und entfernter Branch sind auseinandergelaufen."
+    },
+    "demo": {
+      "title": "Demo-Zustände"
+    },
+    "feedback": {
+      "syncRequested": "Synchronisierung angefordert (Mock).",
+      "resolved": "Auflösung angewendet (Mock): {{resolution}}"
+    },
+    "error": {
+      "unknown": "Unbekannter Synchronisierungsfehler"
     }
   }
 }

--- a/client/src/i18n/i18n.en.json
+++ b/client/src/i18n/i18n.en.json
@@ -251,12 +251,60 @@
   },
   "sync": {
     "title": "Sync",
-    "cta": {
-      "start": "Start sync",
-      "openConflicts": "Open conflicts"
-    },
     "state": {
+      "clean": "In sync",
+      "ahead": "Ahead",
+      "behind": "Behind",
+      "diverged": "Diverged",
+      "running": "Syncing…",
+      "failed": "Sync failed",
       "conflict": "Conflict"
+    },
+    "description": {
+      "clean": "No changes pending. Everything is up to date.",
+      "ahead": "You have {{count}} local change(s) not synced yet.",
+      "behind": "There are {{count}} remote change(s) waiting to be pulled.",
+      "diverged": "Local ({{local}}) and remote ({{remote}}) changes both exist.",
+      "running": "Sync is currently running. Please wait...",
+      "failed": "Sync failed: {{error}}",
+      "conflict": "Conflicts require manual resolution before sync can complete."
+    },
+    "action": {
+      "syncNow": "Sync now",
+      "viewHistory": "View history"
+    },
+    "conflict": {
+      "title": "Resolve conflict: {{file}}",
+      "resolutionOptions": "Resolution options",
+      "keepMine": "Keep mine",
+      "useTheirs": "Use theirs",
+      "aiSuggestion": "AI suggestion",
+      "manual": "Manual edit",
+      "mine": "Keep mine",
+      "theirs": "Use theirs",
+      "ai": "AI suggestion",
+      "cancel": "Cancel",
+      "apply": "Apply resolution"
+    },
+    "history": {
+      "title": "Sync history",
+      "synced": "Synchronization completed successfully.",
+      "localChanges": "Local changes detected.",
+      "started": "Synchronization started.",
+      "failed": "Synchronization failed.",
+      "conflictDetected": "Conflict detected during sync.",
+      "remoteChanges": "Remote changes detected.",
+      "diverged": "Local and remote branches diverged."
+    },
+    "demo": {
+      "title": "Demo states"
+    },
+    "feedback": {
+      "syncRequested": "Sync requested (mock).",
+      "resolved": "Resolution applied (mock): {{resolution}}"
+    },
+    "error": {
+      "unknown": "Unknown sync error"
     }
   }
 }

--- a/client/src/test/unit/components/ConflictResolver.test.tsx
+++ b/client/src/test/unit/components/ConflictResolver.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ConflictResolver from '../../../components/ConflictResolver';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      const translations: Record<string, string> = {
+        'sync.conflict.resolutionOptions': 'Resolution options',
+        'sync.conflict.keepMine': 'Keep mine',
+        'sync.conflict.useTheirs': 'Use theirs',
+        'sync.conflict.aiSuggestion': 'AI suggestion',
+        'sync.conflict.manual': 'Manual edit',
+        'sync.conflict.cancel': 'Cancel',
+        'sync.conflict.apply': 'Apply resolution',
+      };
+      if (key === 'sync.conflict.title') {
+        return `Resolve conflict: ${options?.file ?? ''}`;
+      }
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+describe('ConflictResolver', () => {
+  const conflict = {
+    file: 'project-charter.md',
+    localContent: 'local version',
+    remoteContent: 'remote version',
+  };
+
+  it('renders conflict file and options', () => {
+    render(
+      <ConflictResolver
+        conflict={conflict}
+        onResolve={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Resolve conflict: project-charter.md')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Keep mine' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Use theirs' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'AI suggestion' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Manual edit' })).toBeInTheDocument();
+  });
+
+  it('calls onResolve with selected resolution', () => {
+    const onResolve = vi.fn();
+
+    render(
+      <ConflictResolver
+        conflict={conflict}
+        onResolve={onResolve}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Use theirs' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Apply resolution' }));
+
+    expect(onResolve).toHaveBeenCalledWith('theirs');
+  });
+});

--- a/client/src/test/unit/components/SyncHistory.test.tsx
+++ b/client/src/test/unit/components/SyncHistory.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SyncHistory from '../../../components/SyncHistory';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'sync.history.title': 'Sync history',
+        'sync.state.clean': 'In sync',
+        'sync.state.failed': 'Sync failed',
+        'sync.history.synced': 'Synchronization completed successfully.',
+        'sync.history.failed': 'Synchronization failed.',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+describe('SyncHistory', () => {
+  it('renders title and event rows', () => {
+    render(
+      <SyncHistory
+        events={[
+          {
+            id: '1',
+            timestamp: new Date('2026-02-14T10:00:00.000Z'),
+            state: 'clean',
+            message: 'sync.history.synced',
+          },
+          {
+            id: '2',
+            timestamp: new Date('2026-02-14T09:00:00.000Z'),
+            state: 'failed',
+            message: 'sync.history.failed',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Sync history')).toBeInTheDocument();
+    expect(screen.getByText('In sync')).toBeInTheDocument();
+    expect(screen.getByText('Sync failed')).toBeInTheDocument();
+    expect(screen.getByText('Synchronization completed successfully.')).toBeInTheDocument();
+  });
+});

--- a/client/src/test/unit/components/SyncPanel.test.tsx
+++ b/client/src/test/unit/components/SyncPanel.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import SyncPanel from '../../../components/SyncPanel';
+import type { SyncConflict, SyncState } from '../../../types/sync';
+
+const mockSetDemoState = vi.fn();
+const mockUseSyncStatus = vi.fn(() => ({
+  status: { state: 'clean' as SyncState, localCommits: 0, remoteCommits: 0 },
+  conflicts: [] as SyncConflict[],
+  events: [],
+  availableStates: ['clean', 'ahead', 'behind', 'diverged', 'running', 'failed', 'conflict'] as SyncState[],
+  setDemoState: mockSetDemoState,
+}));
+
+vi.mock('../../../hooks/useSyncStatus', () => ({
+  useSyncStatus: () => mockUseSyncStatus(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string | number>) => {
+      const translations: Record<string, string> = {
+        'sync.title': 'Sync',
+        'sync.state.clean': 'In sync',
+        'sync.state.ahead': 'Ahead',
+        'sync.state.behind': 'Behind',
+        'sync.state.diverged': 'Diverged',
+        'sync.state.running': 'Syncing…',
+        'sync.state.failed': 'Sync failed',
+        'sync.state.conflict': 'Conflict',
+        'sync.action.syncNow': 'Sync now',
+        'sync.action.viewHistory': 'View history',
+        'sync.description.clean': 'No changes pending. Everything is up to date.',
+        'sync.feedback.syncRequested': 'Sync requested (mock).',
+        'sync.demo.title': 'Demo states',
+      };
+      if (key === 'sync.conflict.title') {
+        return `Resolve conflict: ${options?.file ?? ''}`;
+      }
+      if (key === 'sync.description.ahead') {
+        return `You have ${options?.count ?? 0} local change(s) not synced yet.`;
+      }
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+describe('SyncPanel', () => {
+  it('renders sync state and actions', () => {
+    render(
+      <MemoryRouter initialEntries={['/projects/TEST-1/sync']}>
+        <Routes>
+          <Route path="/projects/:projectKey/sync" element={<SyncPanel />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Sync')).toBeInTheDocument();
+    expect(screen.getByText('In sync')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sync now' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'View history' })).toBeInTheDocument();
+  });
+
+  it('allows switching demo states', () => {
+    render(
+      <MemoryRouter initialEntries={['/projects/TEST-1/sync']}>
+        <Routes>
+          <Route path="/projects/:projectKey/sync" element={<SyncPanel />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Ahead/i }));
+    expect(mockSetDemoState).toHaveBeenCalledWith('ahead');
+  });
+
+  it('shows conflict resolver when state is conflict', () => {
+    mockUseSyncStatus.mockReturnValueOnce({
+      status: { state: 'conflict', localCommits: 1, remoteCommits: 1 },
+      conflicts: [
+        {
+          file: 'charter.md',
+          localContent: 'local content',
+          remoteContent: 'remote content',
+        },
+      ],
+      events: [],
+      availableStates: ['clean', 'ahead', 'behind', 'diverged', 'running', 'failed', 'conflict'],
+      setDemoState: mockSetDemoState,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/projects/TEST-1/sync']}>
+        <Routes>
+          <Route path="/projects/:projectKey/sync" element={<SyncPanel />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(/Resolve conflict:/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/types/sync.ts
+++ b/client/src/types/sync.ts
@@ -1,0 +1,31 @@
+export type SyncState =
+  | 'clean'
+  | 'ahead'
+  | 'behind'
+  | 'diverged'
+  | 'running'
+  | 'failed'
+  | 'conflict';
+
+export interface SyncStatus {
+  state: SyncState;
+  localCommits: number;
+  remoteCommits: number;
+  lastSync?: Date;
+  error?: string;
+}
+
+export interface SyncConflict {
+  file: string;
+  localContent: string;
+  remoteContent: string;
+}
+
+export interface SyncEvent {
+  id: string;
+  timestamp: Date;
+  state: SyncState;
+  message: string;
+}
+
+export type ConflictResolution = 'mine' | 'theirs' | 'ai' | 'manual';


### PR DESCRIPTION
# Summary

Implement Phase 2.2 sync UX with a mock-backed sync management route, including sync state visualization, conflict resolution UI, and sync history timeline with full i18n coverage.

## Goal / Acceptance Criteria (required)

**Goal:** Provide clear sync/conflict UI abstractions so users understand sync state and can choose a conflict resolution strategy without Git internals.

**Acceptance Criteria:**

- [x] SyncPanel displays current sync state with icon and description
- [x] States rendered: clean, ahead, behind, diverged, running, failed, conflict
- [x] ConflictResolver shows diff view when conflicts exist
- [x] Resolution options: "Keep mine", "Use theirs", "AI suggestion", "Manual edit"
- [x] SyncHistory shows last 5-10 sync events with timestamps
- [x] All components use i18n (`sync.*` keys)
- [x] Mock data demonstrates all states
- [x] Visual design matches existing UI patterns
- [x] Responsive on mobile/tablet
- [x] Unit tests for all three components
- [x] Lint passes: `npm run lint`
- [x] Build passes: `npm run build`
- [x] Tests pass: `npm test`

## Issue / Tracking Link (required)

Fixes: #154

## What's Included

### Code changes

1. `client/src/types/sync.ts`
   - Added `SyncState`, `SyncStatus`, `SyncConflict`, `SyncEvent`, and `ConflictResolution` domain types.

2. `client/src/hooks/useSyncStatus.ts`
   - Added mock-backed sync state hook with deterministic project-key seeding.
   - Added mock conflicts and sync events.
   - Added `setDemoState` to preview all sync states in UI.

3. `client/src/components/SyncPanel.tsx` + `SyncPanel.css`
   - Added sync state card (icon, title, state, description).
   - Added actions (`Sync now`, `View history`) with running-state disable behavior.
   - Added demo state chips for all required states.
   - Integrated `ConflictResolver` and `SyncHistory` sections.

4. `client/src/components/ConflictResolver.tsx` + `ConflictResolver.css`
   - Added conflict diff presentation (reusing `DiffViewer` split mode).
   - Added radio-based resolution options (`mine/theirs/ai/manual`).
   - Added cancel/apply actions.

5. `client/src/components/SyncHistory.tsx` + `SyncHistory.css`
   - Added sync event timeline with state badges and timestamps.

6. Routing + localization
   - `client/src/App.tsx`: added route `/projects/:projectKey/sync`.
   - `client/src/i18n/i18n.en.json`, `client/src/i18n/i18n.de.json`: expanded `sync.*` keys for states, descriptions, actions, conflict labels, history, demo, feedback, and error text.

7. Unit tests (new)
   - `client/src/test/unit/components/SyncPanel.test.tsx`
   - `client/src/test/unit/components/ConflictResolver.test.tsx`
   - `client/src/test/unit/components/SyncHistory.test.tsx`

## Validation (required)

### Automated checks

- [x] Lint passes
  - Command(s): `cd client && npm run lint`
  - Evidence: `✖ 7 problems (0 errors, 7 warnings)` (pre-existing warnings in coverage files + existing hook warning in `ProposalReview.tsx`)

- [x] Build passes
  - Command(s): `cd client && npm run build`
  - Evidence: `✓ built in 3.77s`

- [x] Tests pass
  - Command(s): `cd client && npm test`
  - Evidence: `Test Files 63 passed (63)` and `Tests 802 passed | 5 skipped (807)`

### Manual test evidence (required)

- [x] Manual test entry #1
  - Scenario: Open `/projects/{projectKey}/sync` and switch through demo states
  - Expected result: icon/title/description updates for clean, ahead, behind, diverged, running, failed, conflict
  - Actual result / Evidence: `SyncPanel` renders all seven states and updates via demo-state chips

- [x] Manual test entry #2
  - Scenario: Conflict state with resolver options
  - Expected result: diff is shown and user can choose mine/theirs/ai/manual before applying
  - Actual result / Evidence: `ConflictResolver` renders split diff, all four options, and apply/cancel actions

## How to review

1. Review `client/src/hooks/useSyncStatus.ts` for mock status/conflict/history modeling and demo-state support.
2. Inspect `client/src/components/SyncPanel.tsx`, `ConflictResolver.tsx`, and `SyncHistory.tsx` for acceptance-criteria UI behavior.
3. Verify route wiring in `client/src/App.tsx` for `/projects/:projectKey/sync`.
4. Validate i18n completeness in `client/src/i18n/i18n.en.json` and `client/src/i18n/i18n.de.json` (`sync.*`).
5. Run:
   - `cd client && npm run lint`
   - `cd client && npm run build`
   - `cd client && npm test`

## Cross-repo / Downstream impact (always include)

- Related repos/services impacted: Backend sync API will be needed for future integration, but not required for this UI-only mock implementation.
- Backend/API contract impact: None in this PR (no client calls to new endpoints yet; TODO integration markers remain in UI logic).
