### PR TITLE
feat: add reusable data table component and integrate project list

### DIFF
--- a/client/src/components/DataTable.css
+++ b/client/src/components/DataTable.css
@@ -1,0 +1,105 @@
+.data-table-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.data-table-desktop {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: auto;
+  outline: none;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #f1f5f9;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.data-table th {
+  background: #f8fafc;
+  font-weight: 600;
+}
+
+.data-table-sort {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0;
+}
+
+.data-table-clickable {
+  cursor: pointer;
+}
+
+.data-table-selected {
+  background: #eff6ff;
+}
+
+.data-table-mobile {
+  display: none;
+}
+
+.data-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.data-card-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.data-card-label {
+  color: #64748b;
+  font-size: 12px;
+}
+
+.data-card-value {
+  font-weight: 500;
+}
+
+.data-table-pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.data-table-pagination-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.data-table-page-size {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+@media (max-width: 768px) {
+  .data-table-desktop {
+    display: none;
+  }
+
+  .data-table-mobile {
+    display: grid;
+    gap: 10px;
+  }
+}

--- a/client/src/components/DataTable.tsx
+++ b/client/src/components/DataTable.tsx
@@ -1,0 +1,298 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import EmptyState from './ui/EmptyState';
+import { LoadingSkeleton } from './LoadingSkeleton';
+import TableFilters from './TableFilters';
+import type { TableColumn, TableFilter, TableSortOrder } from '../types/table';
+import './DataTable.css';
+
+interface DataTableProps<T> {
+  columns: Array<TableColumn<T>>;
+  data: T[];
+  getRowId: (row: T) => string;
+  onRowClick?: (row: T) => void;
+  loading?: boolean;
+  filters?: Array<TableFilter<T>>;
+  pageSizeOptions?: number[];
+  defaultPageSize?: number;
+  queryKeyPrefix?: string;
+  emptyTitle?: string;
+  emptyDescription?: string;
+  emptyCta?: string;
+  onEmptyCta?: () => void;
+}
+
+function compareValues(a: string | number, b: string | number): number {
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  return String(a).localeCompare(String(b), undefined, { sensitivity: 'base' });
+}
+
+export default function DataTable<T>({
+  columns,
+  data,
+  getRowId,
+  onRowClick,
+  loading = false,
+  filters = [],
+  pageSizeOptions = [10, 20, 50],
+  defaultPageSize = 10,
+  queryKeyPrefix = 'table',
+  emptyTitle,
+  emptyDescription,
+  emptyCta,
+  onEmptyCta,
+}: DataTableProps<T>) {
+  const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const queryKey = (name: string) => `${queryKeyPrefix}_${name}`;
+
+  const [sortKey, setSortKey] = useState<string | undefined>(
+    searchParams.get(queryKey('sort')) || undefined,
+  );
+  const [sortOrder, setSortOrder] = useState<TableSortOrder>(
+    (searchParams.get(queryKey('order')) as TableSortOrder) || 'asc',
+  );
+  const [page, setPage] = useState<number>(Number(searchParams.get(queryKey('page')) || '1'));
+  const [pageSize, setPageSize] = useState<number>(
+    Number(searchParams.get(queryKey('pageSize')) || String(defaultPageSize)),
+  );
+  const [selectedRowIndex, setSelectedRowIndex] = useState<number>(0);
+
+  const [filterValues, setFilterValues] = useState<Record<string, string>>(() => {
+    const values: Record<string, string> = {};
+    filters.forEach((filter) => {
+      const paramValue = searchParams.get(queryKey(`filter_${filter.key}`));
+      if (paramValue) values[filter.key] = paramValue;
+    });
+    return values;
+  });
+
+  useEffect(() => {
+    const nextParams = new URLSearchParams(searchParams);
+
+    if (sortKey) nextParams.set(queryKey('sort'), sortKey);
+    else nextParams.delete(queryKey('sort'));
+
+    nextParams.set(queryKey('order'), sortOrder);
+    nextParams.set(queryKey('page'), String(page));
+    nextParams.set(queryKey('pageSize'), String(pageSize));
+
+    filters.forEach((filter) => {
+      const key = queryKey(`filter_${filter.key}`);
+      const value = filterValues[filter.key];
+      if (value) nextParams.set(key, value);
+      else nextParams.delete(key);
+    });
+
+    setSearchParams(nextParams, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sortKey, sortOrder, page, pageSize, filterValues, setSearchParams]);
+
+  const filteredData = useMemo(() => {
+    return data.filter((row) => {
+      return filters.every((filter) => {
+        const value = (filterValues[filter.key] || '').trim();
+        if (!value) return true;
+
+        if (filter.predicate) return filter.predicate(row, value);
+
+        const rowText = (filter.accessor?.(row) || '').toLowerCase();
+        if (filter.type === 'search') {
+          return rowText.includes(value.toLowerCase());
+        }
+        return rowText === value.toLowerCase();
+      });
+    });
+  }, [data, filters, filterValues]);
+
+  const sortedData = useMemo(() => {
+    if (!sortKey) return filteredData;
+    const column = columns.find((c) => String(c.key) === sortKey);
+    if (!column || !column.sortable) return filteredData;
+
+    const sorted = [...filteredData].sort((a, b) => {
+      const aVal = column.sortValue ? column.sortValue(a) : String((a as Record<string, unknown>)[sortKey] || '');
+      const bVal = column.sortValue ? column.sortValue(b) : String((b as Record<string, unknown>)[sortKey] || '');
+      return compareValues(aVal, bVal);
+    });
+
+    return sortOrder === 'asc' ? sorted : sorted.reverse();
+  }, [columns, filteredData, sortKey, sortOrder]);
+
+  const total = sortedData.length;
+  const startIndex = (page - 1) * pageSize;
+  const endIndex = Math.min(startIndex + pageSize, total);
+  const pagedData = sortedData.slice(startIndex, endIndex);
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+
+  useEffect(() => {
+    if (page > pageCount) setPage(pageCount);
+  }, [page, pageCount]);
+
+  useEffect(() => {
+    setSelectedRowIndex(0);
+  }, [page, pageSize, sortKey, sortOrder, filterValues]);
+
+  const toggleSort = (key: string) => {
+    if (sortKey !== key) {
+      setSortKey(key);
+      setSortOrder('asc');
+      return;
+    }
+    setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+  };
+
+  const handleFilterChange = (key: string, value: string) => {
+    setFilterValues((prev) => ({ ...prev, [key]: value }));
+    setPage(1);
+  };
+
+  const onTableKeyDown = (e: React.KeyboardEvent) => {
+    if (!pagedData.length) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedRowIndex((prev) => Math.min(prev + 1, pagedData.length - 1));
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedRowIndex((prev) => Math.max(prev - 1, 0));
+    }
+    if (e.key === 'Enter' && onRowClick) {
+      e.preventDefault();
+      onRowClick(pagedData[selectedRowIndex]);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="data-table-loading">
+        <LoadingSkeleton count={6} />
+      </div>
+    );
+  }
+
+  if (!total) {
+    return (
+      <EmptyState
+        title={emptyTitle || t('table.emptyTitle')}
+        description={emptyDescription || t('table.emptyDescription')}
+        ctaLabel={emptyCta}
+        ctaAction={onEmptyCta}
+      />
+    );
+  }
+
+  return (
+    <div className="data-table-wrapper">
+      {filters.length > 0 && (
+        <TableFilters filters={filters} values={filterValues} onChange={handleFilterChange} />
+      )}
+
+      <div className="data-table-desktop" tabIndex={0} onKeyDown={onTableKeyDown}>
+        <table className="data-table" role="table">
+          <thead>
+            <tr>
+              {columns.map((column) => {
+                const key = String(column.key);
+                const isSorted = sortKey === key;
+                return (
+                  <th key={key} style={column.width ? { width: column.width } : undefined}>
+                    {column.sortable ? (
+                      <button
+                        type="button"
+                        className="data-table-sort"
+                        onClick={() => toggleSort(key)}
+                      >
+                        {column.label}
+                        <span aria-hidden="true">
+                          {isSorted ? (sortOrder === 'asc' ? ' ↑' : ' ↓') : ' ↕'}
+                        </span>
+                      </button>
+                    ) : (
+                      column.label
+                    )}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {pagedData.map((row, index) => (
+              <tr
+                key={getRowId(row)}
+                className={`${onRowClick ? 'data-table-clickable' : ''} ${selectedRowIndex === index ? 'data-table-selected' : ''}`}
+                onClick={() => onRowClick?.(row)}
+              >
+                {columns.map((column) => {
+                  const key = String(column.key);
+                  return (
+                    <td key={key}>
+                      {column.render
+                        ? column.render(row)
+                        : String((row as Record<string, unknown>)[key] ?? '')}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="data-table-mobile">
+        {pagedData.map((row) => (
+          <article key={getRowId(row)} className="data-card" onClick={() => onRowClick?.(row)}>
+            {columns.map((column) => {
+              const key = String(column.key);
+              return (
+                <div key={key} className="data-card-row">
+                  <span className="data-card-label">{column.label}</span>
+                  <span className="data-card-value">
+                    {column.render
+                      ? column.render(row)
+                      : String((row as Record<string, unknown>)[key] ?? '')}
+                  </span>
+                </div>
+              );
+            })}
+          </article>
+        ))}
+      </div>
+
+      <div className="data-table-pagination">
+        <span>
+          {t('table.showing', {
+            start: startIndex + 1,
+            end: endIndex,
+            total,
+          })}
+        </span>
+
+        <div className="data-table-pagination-controls">
+          <button type="button" onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page <= 1}>
+            {t('table.prev')}
+          </button>
+          <span>
+            {page} / {pageCount}
+          </span>
+          <button type="button" onClick={() => setPage((p) => Math.min(pageCount, p + 1))} disabled={page >= pageCount}>
+            {t('table.next')}
+          </button>
+          <label className="data-table-page-size">
+            {t('table.pageSize')}
+            <select value={pageSize} onChange={(e) => { setPageSize(Number(e.target.value)); setPage(1); }}>
+              {pageSizeOptions.map((size) => (
+                <option key={size} value={size}>
+                  {size}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/TableFilters.css
+++ b/client/src/components/TableFilters.css
@@ -1,0 +1,26 @@
+.table-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.table-filter-item {
+  min-width: 200px;
+}
+
+.table-filter-input,
+.table-filter-select {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  font-size: 14px;
+}
+
+.table-filter-input:focus,
+.table-filter-select:focus {
+  outline: none;
+  border-color: #2f81f7;
+  box-shadow: 0 0 0 2px rgba(47, 129, 247, 0.15);
+}

--- a/client/src/components/TableFilters.tsx
+++ b/client/src/components/TableFilters.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from 'react-i18next';
+import type { TableFilter } from '../types/table';
+import './TableFilters.css';
+
+interface TableFiltersProps<T> {
+  filters: Array<TableFilter<T>>;
+  values: Record<string, string>;
+  onChange: (key: string, value: string) => void;
+}
+
+export default function TableFilters<T>({ filters, values, onChange }: TableFiltersProps<T>) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="table-filters" role="search">
+      {filters.map((filter) => (
+        <div key={filter.key} className="table-filter-item">
+          {filter.type === 'search' ? (
+            <input
+              type="text"
+              value={values[filter.key] || ''}
+              placeholder={filter.placeholder || filter.label}
+              aria-label={filter.label}
+              onChange={(e) => onChange(filter.key, e.target.value)}
+              className="table-filter-input"
+            />
+          ) : (
+            <select
+              value={values[filter.key] || ''}
+              aria-label={filter.label}
+              onChange={(e) => onChange(filter.key, e.target.value)}
+              className="table-filter-select"
+            >
+              <option value="">{t('table.all')}</option>
+              {filter.options?.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/__tests__/DataTable.test.tsx
+++ b/client/src/components/__tests__/DataTable.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import DataTable from '../DataTable';
+import type { TableColumn, TableFilter } from '../../types/table';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string | number>) => {
+      if (key === 'table.showing') {
+        return `Showing ${options?.start}-${options?.end} of ${options?.total}`;
+      }
+
+      const translations: Record<string, string> = {
+        'table.all': 'All',
+        'table.search': 'Search',
+        'table.emptyTitle': 'No data available',
+        'table.emptyDescription': 'Try adjusting filters',
+        'table.prev': 'Previous',
+        'table.next': 'Next',
+        'table.pageSize': 'Page size',
+      };
+
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+type Row = {
+  id: string;
+  name: string;
+  status: string;
+  score: number;
+};
+
+const rows: Row[] = [
+  { id: '1', name: 'Bravo', status: 'open', score: 2 },
+  { id: '2', name: 'Alpha', status: 'closed', score: 3 },
+  { id: '3', name: 'Charlie', status: 'open', score: 1 },
+  { id: '4', name: 'Delta', status: 'closed', score: 5 },
+  { id: '5', name: 'Echo', status: 'open', score: 4 },
+  { id: '6', name: 'Foxtrot', status: 'open', score: 6 },
+];
+
+const columns: Array<TableColumn<Row>> = [
+  { key: 'name', label: 'Name', sortable: true, sortValue: (row) => row.name },
+  { key: 'status', label: 'Status', sortable: true, sortValue: (row) => row.status },
+  { key: 'score', label: 'Score', sortable: true, sortValue: (row) => row.score },
+];
+
+const filters: Array<TableFilter<Row>> = [
+  {
+    key: 'search',
+    label: 'Search',
+    type: 'search',
+    accessor: (row) => `${row.name} ${row.status}`.toLowerCase(),
+  },
+  {
+    key: 'status',
+    label: 'Status',
+    type: 'select',
+    accessor: (row) => row.status,
+    options: [
+      { label: 'Open', value: 'open' },
+      { label: 'Closed', value: 'closed' },
+    ],
+  },
+];
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location-search">{location.search}</div>;
+}
+
+function renderTable(onRowClick?: (row: Row) => void, initialPath = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="/"
+          element={(
+            <>
+              <DataTable
+                columns={columns}
+                data={rows}
+                filters={filters}
+                getRowId={(row) => row.id}
+                onRowClick={onRowClick}
+                queryKeyPrefix="test"
+                defaultPageSize={5}
+              />
+              <LocationProbe />
+            </>
+          )}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('DataTable', () => {
+  it('sorts rows when column header clicked', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    const nameSort = screen.getByRole('button', { name: /name/i });
+    await user.click(nameSort);
+
+    const tableRows = screen.getAllByRole('row');
+    expect(tableRows[1]).toHaveTextContent('Alpha');
+
+    await user.click(nameSort);
+    const rowsDesc = screen.getAllByRole('row');
+    expect(rowsDesc[1]).toHaveTextContent('Foxtrot');
+  });
+
+  it('filters by search and select controls', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    await user.type(screen.getByRole('textbox', { name: 'Search' }), 'alpha');
+    expect(screen.getAllByText('Alpha').length).toBeGreaterThan(0);
+    expect(screen.queryAllByText('Bravo')).toHaveLength(0);
+
+    await user.clear(screen.getByRole('textbox', { name: 'Search' }));
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Status' }), 'closed');
+
+    expect(screen.getAllByText('Alpha').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Delta').length).toBeGreaterThan(0);
+    expect(screen.queryAllByText('Bravo')).toHaveLength(0);
+  });
+
+  it('paginates data and allows next page navigation', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    expect(screen.getByText('Showing 1-5 of 6')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(screen.getByText('Showing 6-6 of 6')).toBeInTheDocument();
+    expect(screen.getAllByText('Foxtrot').length).toBeGreaterThan(0);
+  });
+
+  it('syncs state to query params', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    await user.click(screen.getByRole('button', { name: /score/i }));
+    await user.type(screen.getByRole('textbox', { name: 'Search' }), 'bravo');
+
+    const queryString = screen.getByTestId('location-search').textContent || '';
+    expect(queryString).toContain('test_sort=score');
+    expect(queryString).toContain('test_filter_search=bravo');
+  });
+
+  it('supports keyboard navigation and enter activation', async () => {
+    const user = userEvent.setup();
+    const onRowClick = vi.fn();
+    renderTable(onRowClick);
+
+    const tableContainer = screen.getByRole('table').closest('.data-table-desktop') as HTMLElement | null;
+    tableContainer?.focus();
+
+    await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick).toHaveBeenCalledWith(expect.objectContaining({ name: 'Charlie' }));
+  });
+
+  it('renders empty state when no rows are available', () => {
+    render(
+      <MemoryRouter>
+        <DataTable
+          columns={columns}
+          data={[]}
+          getRowId={(row) => row.id}
+          queryKeyPrefix="empty"
+          emptyTitle="Nothing here"
+          emptyDescription="Create something first"
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+    expect(screen.getByText('Create something first')).toBeInTheDocument();
+  });
+});

--- a/client/src/i18n/i18n.de.json
+++ b/client/src/i18n/i18n.de.json
@@ -38,6 +38,12 @@
   "projects": {
     "list": {
       "title": "Projekte",
+      "table": {
+        "name": "Name",
+        "description": "Beschreibung",
+        "branch": "Branch",
+        "searchPlaceholder": "Nach Schlüssel, Name oder Beschreibung suchen"
+      },
       "cta": {
         "new": "Neues Projekt",
         "import": "Importieren"
@@ -79,6 +85,16 @@
         "requiredKeyAndName": "Projektschlüssel und Projektname sind erforderlich"
       }
     }
+  },
+  "table": {
+    "all": "Alle",
+    "search": "Suchen",
+    "emptyTitle": "Keine Daten verfügbar",
+    "emptyDescription": "Passe die Filter an oder erstelle neue Daten.",
+    "prev": "Zurück",
+    "next": "Weiter",
+    "pageSize": "Seitengröße",
+    "showing": "Zeige {{start}}-{{end}} von {{total}}"
   },
   "projectView": {
     "actions": {

--- a/client/src/i18n/i18n.en.json
+++ b/client/src/i18n/i18n.en.json
@@ -38,6 +38,12 @@
   "projects": {
     "list": {
       "title": "Projects",
+      "table": {
+        "name": "Name",
+        "description": "Description",
+        "branch": "Branch",
+        "searchPlaceholder": "Search by key, name, or description"
+      },
       "cta": {
         "new": "New project",
         "import": "Import"
@@ -79,6 +85,16 @@
         "requiredKeyAndName": "Project key and name are required"
       }
     }
+  },
+  "table": {
+    "all": "All",
+    "search": "Search",
+    "emptyTitle": "No data available",
+    "emptyDescription": "Try adjusting filters or create new data.",
+    "prev": "Previous",
+    "next": "Next",
+    "pageSize": "Page size",
+    "showing": "Showing {{start}}-{{end}} of {{total}}"
   },
   "projectView": {
     "actions": {

--- a/client/src/types/table.ts
+++ b/client/src/types/table.ts
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+
+export type TableSortOrder = 'asc' | 'desc';
+
+export interface TableColumn<T> {
+  key: keyof T | string;
+  label: string;
+  sortable?: boolean;
+  width?: string;
+  render?: (row: T) => ReactNode;
+  sortValue?: (row: T) => string | number;
+}
+
+export interface TableFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface TableFilter<T> {
+  key: string;
+  label: string;
+  type: 'search' | 'select';
+  placeholder?: string;
+  options?: TableFilterOption[];
+  accessor?: (row: T) => string;
+  predicate?: (row: T, value: string) => boolean;
+}
+
+export interface TableState {
+  sortKey?: string;
+  sortOrder: TableSortOrder;
+  page: number;
+  pageSize: number;
+  filters: Record<string, string>;
+}


### PR DESCRIPTION
# Summary

Implement issue #159 by introducing a reusable, generic `DataTable` system (sorting/filtering/pagination/query-sync/keyboard navigation/responsive cards), integrating it into `ProjectList`, and adding EN/DE i18n plus focused table tests.

## Goal / Acceptance Criteria (required)

**Goal:** Deliver a reusable table foundation for client list views, then adopt it in project listing with test coverage and URL-state behavior.

**Acceptance Criteria:**

- [x] Generic reusable table component created for list views
- [x] Configurable column definitions with custom renderers
- [x] Built-in sorting support (asc/desc)
- [x] Built-in filtering support (search/select)
- [x] Pagination support with configurable page size
- [x] Query parameter synchronization for table state
- [x] Keyboard navigation support (arrow keys + enter)
- [x] Responsive table/cards behavior for mobile
- [x] Integrated into project listing view
- [x] i18n coverage added for new table labels/messages
- [x] Unit tests added for table behavior
- [x] Lint passes: `npm run lint`
- [x] Build passes: `npm run build`
- [x] Tests pass: `npm run test`

## Issue / Tracking Link (required)

Fixes: #159

## What's Included

### Code changes

1. Reusable table foundation
   - `client/src/types/table.ts`
   - `client/src/components/DataTable.tsx`
   - `client/src/components/DataTable.css`
   - `client/src/components/TableFilters.tsx`
   - `client/src/components/TableFilters.css`
   - Added generic column/filter typing and shared table UI with sorting, filters, pagination, URL query sync, keyboard nav, and responsive card rendering.

2. Project list integration
   - `client/src/components/ProjectList.tsx`
   - Replaced project card grid rendering with reusable `DataTable` integration while preserving create form and row navigation.

3. Localization
   - `client/src/i18n/i18n.en.json`
   - `client/src/i18n/i18n.de.json`
   - Added `table.*` generic labels and `projects.list.table.*` entries.

4. Tests
   - `client/src/components/__tests__/DataTable.test.tsx`
   - Added tests for sorting, filtering, pagination, query-sync, keyboard navigation, and empty state.

## Validation (required)

### Automated checks

- [x] Lint passes
  - Command(s): `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm run lint`
  - Evidence: completed with warnings only (no errors).

- [x] Build passes
  - Command(s): `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm run build`
  - Evidence: `✓ built in 4.10s`.

- [x] Tests pass
  - Command(s):
    - `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm run test -- src/components/__tests__/DataTable.test.tsx`
    - `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm run test`
  - Evidence: focused suite `1 passed (6 tests)` and full suite `70 passed`, `828 passed | 5 skipped`.

### Manual test evidence (required)

- [x] Manual test entry #1
  - Scenario: Sort and paginate data in reusable table.
  - Expected result: rows reorder and page summary updates.
  - Actual result / Evidence: validated by `DataTable.test.tsx` sorting + pagination assertions.

- [x] Manual test entry #2
  - Scenario: Apply search/select filters and verify URL synchronization.
  - Expected result: visible rows filter correctly and query string reflects filter/sort state.
  - Actual result / Evidence: validated by `DataTable.test.tsx` filter and query-param tests.

## How to review

1. Review `client/src/types/table.ts` for reusable table/filter contracts.
2. Review `client/src/components/DataTable.tsx` and `TableFilters.tsx` for behavior (sorting/filtering/pagination/query-sync/keyboard nav).
3. Review `client/src/components/ProjectList.tsx` for adoption and row navigation behavior.
4. Verify new localization keys in `client/src/i18n/i18n.en.json` and `client/src/i18n/i18n.de.json`.
5. Run:
   - `cd client && npm run test -- src/components/__tests__/DataTable.test.tsx`
   - `cd client && npm run test`
   - `cd client && npm run build`

## Cross-repo / Downstream impact (always include)

- Related repos/services impacted: None required for this change.
- Backend/API contract impact: None.
