### PR TITLE
feat: standardize review gate pattern

### DIFF
--- a/client/src/components/ReviewGate.css
+++ b/client/src/components/ReviewGate.css
@@ -1,0 +1,149 @@
+.review-gate {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.review-gate-diff-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.review-gate-side-by-side {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.review-gate-side-by-side section,
+.review-gate-inline,
+.review-gate-unified,
+.review-gate-checks {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #fff;
+  padding: 0.75rem;
+}
+
+.review-gate-side-by-side pre,
+.review-gate-inline pre {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.85rem;
+}
+
+.review-gate-line {
+  display: grid;
+  grid-template-columns: 3rem 3rem 1rem 1fr;
+  gap: 0.5rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.85rem;
+  padding: 0.15rem 0.25rem;
+}
+
+.review-gate-line-add {
+  background: #ecfdf3;
+}
+
+.review-gate-line-remove {
+  background: #fef2f2;
+}
+
+.line-number {
+  color: #64748b;
+  text-align: right;
+}
+
+.review-gate-check {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  padding: 0.5rem;
+  border-radius: 6px;
+}
+
+.review-gate-check-pass {
+  background: #ecfdf3;
+}
+
+.review-gate-check-fail {
+  background: #fef2f2;
+}
+
+.review-gate-check-warning {
+  background: #fffbeb;
+}
+
+.review-gate-check-pending {
+  background: #eff6ff;
+}
+
+.review-gate-check-message {
+  margin: 0.2rem 0 0;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.review-gate-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.review-gate-actions button {
+  padding: 0.5rem 0.8rem;
+  border-radius: 6px;
+  border: 1px solid #cbd5e1;
+  background: white;
+  cursor: pointer;
+}
+
+.review-gate-actions .review-gate-approve {
+  background: #2563eb;
+  color: #fff;
+  border-color: #2563eb;
+}
+
+.review-gate-actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.review-gate-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.review-gate-modal {
+  width: min(500px, calc(100vw - 2rem));
+  background: white;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  padding: 1rem;
+}
+
+.review-gate-modal textarea {
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 0.5rem;
+}
+
+.review-gate-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+@media (max-width: 768px) {
+  .review-gate-side-by-side {
+    grid-template-columns: 1fr;
+  }
+}

--- a/client/src/components/ReviewGate.tsx
+++ b/client/src/components/ReviewGate.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { DiffLine, ReviewGateProps } from '../types/reviewGate';
+import './ReviewGate.css';
+
+type DiffMode = 'side-by-side' | 'unified' | 'inline';
+
+function buildDiffLines(before: string, after: string): DiffLine[] {
+  const oldLines = before.split('\n');
+  const newLines = after.split('\n');
+  const maxLen = Math.max(oldLines.length, newLines.length);
+  const lines: DiffLine[] = [];
+
+  for (let i = 0; i < maxLen; i += 1) {
+    const oldLine = oldLines[i];
+    const newLine = newLines[i];
+
+    if (oldLine === newLine && oldLine !== undefined) {
+      lines.push({
+        type: 'unchanged',
+        content: oldLine,
+        oldLineNumber: i + 1,
+        newLineNumber: i + 1,
+      });
+      continue;
+    }
+
+    if (oldLine !== undefined) {
+      lines.push({
+        type: 'remove',
+        content: oldLine,
+        oldLineNumber: i + 1,
+      });
+    }
+
+    if (newLine !== undefined) {
+      lines.push({
+        type: 'add',
+        content: newLine,
+        newLineNumber: i + 1,
+      });
+    }
+  }
+
+  return lines;
+}
+
+export default function ReviewGate({
+  diff,
+  checks,
+  onApprove,
+  onReject,
+  onEdit,
+  approveLabel,
+  rejectLabel,
+  editLabel,
+}: ReviewGateProps) {
+  const { t } = useTranslation();
+  const [diffMode, setDiffMode] = useState<DiffMode>('side-by-side');
+  const [loading, setLoading] = useState(false);
+  const [showRejectModal, setShowRejectModal] = useState(false);
+  const [rejectReason, setRejectReason] = useState('');
+
+  const diffLines = useMemo(() => diff.lines || buildDiffLines(diff.before, diff.after), [diff]);
+
+  const canApprove = checks.every(
+    (check) => !(check.status === 'fail' && check.blocking !== false),
+  );
+
+  const handleApprove = async () => {
+    if (!canApprove || loading) return;
+    setLoading(true);
+    try {
+      await onApprove();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRejectConfirm = async () => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      await onReject(rejectReason.trim() || undefined);
+      setShowRejectModal(false);
+      setRejectReason('');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+        event.preventDefault();
+        handleApprove();
+      }
+
+      if (event.key === 'Escape') {
+        setShowRejectModal(false);
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  });
+
+  const resolveCheckIcon = (status: string): string => {
+    if (status === 'pass') return '✅';
+    if (status === 'fail') return '❌';
+    if (status === 'warning') return '⚠️';
+    return '⏳';
+  };
+
+  return (
+    <div className="review-gate" data-testid="review-gate">
+      <div className="review-gate-diff-header">
+        <label htmlFor="review-gate-diff-mode">{t('reviewGate.diff.modeLabel')}</label>
+        <select
+          id="review-gate-diff-mode"
+          value={diffMode}
+          onChange={(event) => setDiffMode(event.target.value as DiffMode)}
+        >
+          <option value="side-by-side">{t('reviewGate.diff.sideBySide')}</option>
+          <option value="unified">{t('reviewGate.diff.unified')}</option>
+          <option value="inline">{t('reviewGate.diff.inline')}</option>
+        </select>
+      </div>
+
+      {diffMode === 'side-by-side' && (
+        <div className="review-gate-side-by-side">
+          <section>
+            <h4>{t('reviewGate.diff.before')}</h4>
+            <pre>{diff.before}</pre>
+          </section>
+          <section>
+            <h4>{t('reviewGate.diff.after')}</h4>
+            <pre>{diff.after}</pre>
+          </section>
+        </div>
+      )}
+
+      {diffMode === 'inline' && (
+        <div className="review-gate-inline" data-testid="review-inline">
+          <h4>{t('reviewGate.diff.before')}</h4>
+          <pre>{diff.before}</pre>
+          <h4>{t('reviewGate.diff.after')}</h4>
+          <pre>{diff.after}</pre>
+        </div>
+      )}
+
+      {diffMode === 'unified' && (
+        <div className="review-gate-unified" data-testid="review-unified">
+          {diffLines.map((line, index) => (
+            <div
+              key={`${line.type}-${line.oldLineNumber || 0}-${line.newLineNumber || 0}-${index}`}
+              className={`review-gate-line review-gate-line-${line.type}`}
+            >
+              <span className="line-number old">{line.oldLineNumber || ''}</span>
+              <span className="line-number new">{line.newLineNumber || ''}</span>
+              <span className="line-prefix">
+                {line.type === 'add' ? '+' : line.type === 'remove' ? '-' : ' '}
+              </span>
+              <span className="line-content">{line.content}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="review-gate-checks">
+        <h4>{t('reviewGate.checks.title')}</h4>
+        {checks.map((check) => (
+          <div key={check.id} className={`review-gate-check review-gate-check-${check.status}`}>
+            <span className="review-gate-check-icon">{resolveCheckIcon(check.status)}</span>
+            <div>
+              <span className="review-gate-check-label">{check.label}</span>
+              {check.message && <p className="review-gate-check-message">{check.message}</p>}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="review-gate-actions">
+        {onEdit && (
+          <button type="button" onClick={onEdit} disabled={loading}>
+            {editLabel || t('reviewGate.actions.edit')}
+          </button>
+        )}
+        <button type="button" onClick={() => setShowRejectModal(true)} disabled={loading}>
+          {rejectLabel || t('reviewGate.actions.reject')}
+        </button>
+        <button
+          type="button"
+          className="review-gate-approve"
+          onClick={handleApprove}
+          disabled={!canApprove || loading}
+          title={!canApprove ? t('reviewGate.actions.approveBlocked') : ''}
+        >
+          {loading ? t('reviewGate.actions.applying') : approveLabel || t('reviewGate.actions.approve')}
+        </button>
+      </div>
+
+      {showRejectModal && (
+        <div className="review-gate-modal-overlay" role="dialog" aria-modal="true">
+          <div className="review-gate-modal">
+            <h3>{t('reviewGate.reject.title')}</h3>
+            <label htmlFor="review-gate-reject-reason">{t('reviewGate.reject.reasonLabel')}</label>
+            <textarea
+              id="review-gate-reject-reason"
+              value={rejectReason}
+              onChange={(event) => setRejectReason(event.target.value)}
+              placeholder={t('reviewGate.reject.reasonPlaceholder')}
+              rows={4}
+            />
+            <div className="review-gate-modal-actions">
+              <button type="button" onClick={() => setShowRejectModal(false)} disabled={loading}>
+                {t('reviewGate.reject.cancel')}
+              </button>
+              <button type="button" onClick={handleRejectConfirm} disabled={loading}>
+                {t('reviewGate.reject.confirm')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/__tests__/ReviewGate.test.tsx
+++ b/client/src/components/__tests__/ReviewGate.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ReviewGate from '../ReviewGate';
+import type { ValidationCheck } from '../../types/reviewGate';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'reviewGate.diff.modeLabel': 'View',
+        'reviewGate.diff.sideBySide': 'Side-by-Side',
+        'reviewGate.diff.unified': 'Unified',
+        'reviewGate.diff.inline': 'Inline',
+        'reviewGate.diff.before': 'Current',
+        'reviewGate.diff.after': 'Proposed',
+        'reviewGate.checks.title': 'Validation Checks',
+        'reviewGate.actions.approve': 'Apply Changes',
+        'reviewGate.actions.reject': 'Reject',
+        'reviewGate.actions.edit': 'Edit',
+        'reviewGate.actions.applying': 'Processing...',
+        'reviewGate.actions.approveBlocked': 'Fix blocking checks',
+        'reviewGate.reject.title': 'Reject Changes',
+        'reviewGate.reject.reasonLabel': 'Reason (optional)',
+        'reviewGate.reject.reasonPlaceholder': 'Explain why',
+        'reviewGate.reject.cancel': 'Cancel',
+        'reviewGate.reject.confirm': 'Reject',
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+const passingChecks: ValidationCheck[] = [
+  { id: '1', label: 'Syntax valid', status: 'pass', blocking: true },
+  { id: '2', label: 'No conflicts', status: 'pass', blocking: true },
+];
+
+describe('ReviewGate', () => {
+  it('renders validation checks and diff controls', () => {
+    render(
+      <ReviewGate
+        diff={{ before: 'old line', after: 'new line' }}
+        checks={passingChecks}
+        onApprove={vi.fn().mockResolvedValue(undefined)}
+        onReject={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.getByTestId('review-gate')).toBeInTheDocument();
+    expect(screen.getByText('Validation Checks')).toBeInTheDocument();
+    expect(screen.getByText('Syntax valid')).toBeInTheDocument();
+    expect(screen.getByLabelText('View')).toBeInTheDocument();
+  });
+
+  it('disables approve button when blocking check fails', () => {
+    render(
+      <ReviewGate
+        diff={{ before: 'a', after: 'b' }}
+        checks={[{ id: 'blocked', label: 'Has conflicts', status: 'fail', blocking: true }]}
+        onApprove={vi.fn().mockResolvedValue(undefined)}
+        onReject={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Apply Changes' })).toBeDisabled();
+  });
+
+  it('calls onApprove when approve clicked', async () => {
+    const user = userEvent.setup();
+    const onApprove = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ReviewGate
+        diff={{ before: 'a', after: 'b' }}
+        checks={passingChecks}
+        onApprove={onApprove}
+        onReject={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Apply Changes' }));
+    expect(onApprove).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens reject modal and calls onReject with reason', async () => {
+    const user = userEvent.setup();
+    const onReject = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ReviewGate
+        diff={{ before: 'a', after: 'b' }}
+        checks={passingChecks}
+        onApprove={vi.fn().mockResolvedValue(undefined)}
+        onReject={onReject}
+      />,
+    );
+
+    await user.click(screen.getAllByRole('button', { name: 'Reject' })[0]);
+    await user.type(screen.getByLabelText('Reason (optional)'), 'Needs revision');
+    await user.click(screen.getAllByRole('button', { name: 'Reject' })[1]);
+
+    expect(onReject).toHaveBeenCalledWith('Needs revision');
+  });
+
+  it('supports keyboard shortcut Ctrl+Enter to approve', async () => {
+    const user = userEvent.setup();
+    const onApprove = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ReviewGate
+        diff={{ before: 'a', after: 'b' }}
+        checks={passingChecks}
+        onApprove={onApprove}
+        onReject={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    await user.keyboard('{Control>}{Enter}{/Control}');
+    expect(onApprove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/i18n/i18n.de.json
+++ b/client/src/i18n/i18n.de.json
@@ -343,6 +343,54 @@
       "reject": "Verwerfen"
     }
   },
+  "reviewGate": {
+    "diff": {
+      "title": "Änderungen",
+      "modeLabel": "Ansicht",
+      "sideBySide": "Nebeneinander",
+      "unified": "Vereinheitlicht",
+      "inline": "Inline",
+      "before": "Aktuell",
+      "after": "Vorgeschlagen"
+    },
+    "checks": {
+      "title": "Validierungsprüfungen"
+    },
+    "actions": {
+      "approve": "Änderungen anwenden",
+      "reject": "Verwerfen",
+      "edit": "Bearbeiten",
+      "applying": "Wird verarbeitet...",
+      "approveBlocked": "Behebe blockierende Prüfungen vor dem Anwenden"
+    },
+    "reject": {
+      "title": "Änderungen verwerfen",
+      "reasonLabel": "Grund (optional)",
+      "reasonPlaceholder": "Erkläre, warum diese Änderungen verworfen werden...",
+      "cancel": "Abbrechen",
+      "confirm": "Verwerfen"
+    },
+    "meta": {
+      "target": "Ziel",
+      "changeType": "Änderungstyp",
+      "status": "Status",
+      "author": "Autor",
+      "rationale": "Begründung",
+      "alreadyProcessed": "Dieser Vorschlag wurde bereits {{status}}."
+    },
+    "defaultChecks": {
+      "syntaxValid": "Syntax gültig",
+      "noConflicts": "Keine Konflikte",
+      "changeSize": "Änderungsumfang",
+      "changeSizeWarning": "Großer Änderungssatz. Bitte sorgfältig prüfen."
+    },
+    "toasts": {
+      "approveSuccess": "Änderungen erfolgreich angewendet",
+      "approveFailed": "Änderungen konnten nicht angewendet werden",
+      "rejectSuccess": "Änderungen verworfen",
+      "rejectFailed": "Änderungen konnten nicht verworfen werden"
+    }
+  },
   "rd": {
     "title": "Readiness Builder",
     "loading": "Readiness wird geladen...",

--- a/client/src/i18n/i18n.en.json
+++ b/client/src/i18n/i18n.en.json
@@ -343,6 +343,54 @@
       "reject": "Reject"
     }
   },
+  "reviewGate": {
+    "diff": {
+      "title": "Changes",
+      "modeLabel": "View",
+      "sideBySide": "Side-by-Side",
+      "unified": "Unified",
+      "inline": "Inline",
+      "before": "Current",
+      "after": "Proposed"
+    },
+    "checks": {
+      "title": "Validation Checks"
+    },
+    "actions": {
+      "approve": "Apply Changes",
+      "reject": "Reject",
+      "edit": "Edit",
+      "applying": "Processing...",
+      "approveBlocked": "Fix blocking checks before applying"
+    },
+    "reject": {
+      "title": "Reject Changes",
+      "reasonLabel": "Reason (optional)",
+      "reasonPlaceholder": "Explain why these changes are rejected...",
+      "cancel": "Cancel",
+      "confirm": "Reject"
+    },
+    "meta": {
+      "target": "Target",
+      "changeType": "Change Type",
+      "status": "Status",
+      "author": "Author",
+      "rationale": "Rationale",
+      "alreadyProcessed": "This proposal has already been {{status}}."
+    },
+    "defaultChecks": {
+      "syntaxValid": "Syntax valid",
+      "noConflicts": "No conflicts",
+      "changeSize": "Change size",
+      "changeSizeWarning": "Large change set. Please review carefully."
+    },
+    "toasts": {
+      "approveSuccess": "Changes applied successfully",
+      "approveFailed": "Failed to apply changes",
+      "rejectSuccess": "Changes rejected",
+      "rejectFailed": "Failed to reject changes"
+    }
+  },
   "rd": {
     "title": "Readiness Builder",
     "loading": "Loading readiness...",

--- a/client/src/types/reviewGate.ts
+++ b/client/src/types/reviewGate.ts
@@ -1,0 +1,35 @@
+export type DiffLineType = 'add' | 'remove' | 'unchanged';
+
+export interface DiffLine {
+  type: DiffLineType;
+  content: string;
+  oldLineNumber?: number;
+  newLineNumber?: number;
+}
+
+export interface DiffView {
+  before: string;
+  after: string;
+  lines?: DiffLine[];
+}
+
+export type CheckStatus = 'pass' | 'fail' | 'warning' | 'pending';
+
+export interface ValidationCheck {
+  id: string;
+  label: string;
+  status: CheckStatus;
+  message?: string;
+  blocking?: boolean;
+}
+
+export interface ReviewGateProps {
+  diff: DiffView;
+  checks: ValidationCheck[];
+  onApprove: () => Promise<void>;
+  onReject: (reason?: string) => Promise<void>;
+  onEdit?: () => void;
+  approveLabel?: string;
+  rejectLabel?: string;
+  editLabel?: string;
+}


### PR DESCRIPTION
# Summary

Implement Phase 5.2 by introducing a reusable `ReviewGate` component (diff modes + validation checks + approve/reject flow), integrating it into `ProposalReview`, and adding i18n + tests for standardized review UX.

## Goal / Acceptance Criteria (required)

**Goal:** Standardize the review gate pattern (`diff → checks → apply/reject`) to reduce duplicated review logic and provide consistent interaction behavior.

**Acceptance Criteria:**

- [x] ReviewGate component with TypeScript interfaces
- [x] Props include: `diff`, `checks`, `onApprove`, `onReject`, `onEdit`
- [x] Diff display modes: side-by-side, unified, inline
- [x] Validation checklist with pass/fail/warning/pending states
- [x] Apply button enabled only when blocking checks pass
- [x] Reject flow with reason input modal
- [x] Edit action supported via optional callback prop
- [x] Keyboard shortcuts (`Ctrl+Enter`, `Esc`)
- [x] All strings use i18n keys
- [x] Loading state during approve/reject
- [x] Success/error toast notifications in integration flow
- [x] Unit tests for review-gate validation behavior
- [x] Integration tests for proposal approval/rejection flow
- [x] Lint passes: `npm run lint`
- [x] Build passes: `npm run build`
- [x] Tests pass: `npm test`

## Issue / Tracking Link (required)

Fixes: #160

## What's Included

### Code changes

1. New reusable review gate types/component
   - `client/src/types/reviewGate.ts`
   - `client/src/components/ReviewGate.tsx`
   - `client/src/components/ReviewGate.css`
   - Added generic diff/check/action contract, diff mode switching, keyboard shortcuts, reject modal, and blocking-check approval gating.

2. Proposal review integration
   - `client/src/components/ProposalReview.tsx`
   - Replaced ad-hoc confirm/prompt/alert flow with reusable `ReviewGate` for pending proposals; kept read-only diff for accepted/rejected proposals.

3. Localization
   - `client/src/i18n/i18n.en.json`
   - `client/src/i18n/i18n.de.json`
   - Added `reviewGate.*` keys for labels/actions/checks/toasts/messages.

4. Tests
   - `client/src/components/__tests__/ReviewGate.test.tsx`
   - `client/src/components/__tests__/ProposalReview.test.tsx`
   - Added unit tests for gating logic/keyboard shortcuts and updated integration tests for new modal-based reject + toast-based outcomes.

## Validation (required)

### Automated checks

- [x] Lint passes
  - Command(s): `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm run lint`
  - Evidence: command completed with warnings only (no ESLint errors).

- [x] Build passes
  - Command(s): `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm run build`
  - Evidence: `✓ built in 3.48s`.

- [x] Tests pass
  - Command(s):
    - `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm run test -- src/components/__tests__/ReviewGate.test.tsx src/components/__tests__/ProposalReview.test.tsx`
    - `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm run test`
  - Evidence: focused suites `2 passed (16 tests)` and full suite `71 passed`, `831 passed | 5 skipped`.

### Manual test evidence (required)

- [x] Manual test entry #1
  - Scenario: Pending proposal review with validation checks and approve action.
  - Expected result: apply action available only when blocking checks pass; apply triggers proposal apply flow.
  - Actual result / Evidence: covered by `ReviewGate.test.tsx` (`disables approve when blocking fail`, `calls onApprove`) and `ProposalReview.test.tsx` (`handles apply action`).

- [x] Manual test entry #2
  - Scenario: Reject proposal via modal with optional reason.
  - Expected result: reject modal opens, reason can be entered, reject API is called, toast feedback shown.
  - Actual result / Evidence: covered by `ProposalReview.test.tsx` (`handles reject action with reason`, `displays error message on reject failure`).

## How to review

1. Review `client/src/types/reviewGate.ts` and `client/src/components/ReviewGate.tsx` for reusable API and behavior.
2. Review `client/src/components/ProposalReview.tsx` for integration and state handling.
3. Review `client/src/i18n/i18n.en.json` and `client/src/i18n/i18n.de.json` for new `reviewGate.*` keys.
4. Review test coverage in `client/src/components/__tests__/ReviewGate.test.tsx` and `ProposalReview.test.tsx`.
5. Run:
   - `cd client && npm run lint`
   - `cd client && npm run test -- src/components/__tests__/ReviewGate.test.tsx src/components/__tests__/ProposalReview.test.tsx`
   - `cd client && npm run test && npm run build`

## Cross-repo / Downstream impact (always include)

- Related repos/services impacted: None required.
- Backend/API contract impact: None (existing proposal endpoints reused).
