### PR TITLE
refactor(api): decompose apiClient.ts into domain clients

### DIFF
--- a/client/src/services/RaidApiClient.ts
+++ b/client/src/services/RaidApiClient.ts
@@ -1,0 +1,156 @@
+import axios, { type AxiosError, type AxiosInstance, isAxiosError } from 'axios';
+import type {
+  RAIDItem,
+  RAIDItemCreate,
+  RAIDItemList,
+  RAIDItemUpdate,
+  RAIDPriority,
+  RAIDStatus,
+  RAIDType,
+} from '../types';
+import {
+  ApiError,
+  AuthenticationError,
+  NetworkError,
+  NotFoundError,
+  ServerError,
+} from './errors';
+
+export type RaidListFilters = {
+  type?: RAIDType;
+  status?: RAIDStatus;
+  owner?: string;
+  priority?: RAIDPriority;
+};
+
+export class RaidApiClient {
+  private client: AxiosInstance;
+
+  constructor(baseUrl?: string, apiKey?: string) {
+    const apiBaseUrl = baseUrl || import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+
+    this.client = axios.create({
+      baseURL: apiBaseUrl,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
+      },
+      timeout: 30000,
+    });
+  }
+
+  private handleError(error: unknown): never {
+    if (!isAxiosError(error)) {
+      throw new ApiError({
+        type: 'unknown',
+        message: error instanceof Error ? error.message : 'An unknown error occurred',
+        retryable: false,
+        originalError: error,
+      });
+    }
+
+    const axiosError = error as AxiosError;
+
+    if (!axiosError.response) {
+      throw new NetworkError(
+        'Network error: Could not connect to server. Please check your connection.',
+        axiosError,
+      );
+    }
+
+    const status = axiosError.response.status;
+    const responseData = axiosError.response.data as
+      | { message?: string; detail?: string }
+      | undefined;
+    const message = responseData?.detail || responseData?.message || `API Error: ${status}`;
+
+    if (status === 401) {
+      throw new AuthenticationError(message, status);
+    }
+
+    if (status === 404) {
+      throw new NotFoundError(message, 'raid_item');
+    }
+
+    if (status >= 500) {
+      throw new ServerError(message, status, axiosError);
+    }
+
+    throw new ApiError({
+      type: 'unknown',
+      message,
+      statusCode: status,
+      retryable: false,
+      originalError: axiosError,
+    });
+  }
+
+  async listRAIDItems(
+    projectKey: string,
+    filters?: RaidListFilters,
+  ): Promise<RAIDItemList> {
+    try {
+      const params = new URLSearchParams();
+      if (filters?.type) params.append('type', filters.type);
+      if (filters?.status) params.append('status', filters.status);
+      if (filters?.owner) params.append('owner', filters.owner);
+      if (filters?.priority) params.append('priority', filters.priority);
+
+      const queryString = params.toString();
+      const url = `/projects/${projectKey}/raid${queryString ? `?${queryString}` : ''}`;
+      const response = await this.client.get<RAIDItemList>(url);
+      return response.data;
+    } catch (error) {
+      return this.handleError(error);
+    }
+  }
+
+  async getRAIDItem(projectKey: string, raidId: string): Promise<RAIDItem> {
+    try {
+      const response = await this.client.get<RAIDItem>(
+        `/projects/${projectKey}/raid/${raidId}`,
+      );
+      return response.data;
+    } catch (error) {
+      return this.handleError(error);
+    }
+  }
+
+  async createRAIDItem(projectKey: string, data: RAIDItemCreate): Promise<RAIDItem> {
+    try {
+      const response = await this.client.post<RAIDItem>(`/projects/${projectKey}/raid`, data);
+      return response.data;
+    } catch (error) {
+      return this.handleError(error);
+    }
+  }
+
+  async updateRAIDItem(
+    projectKey: string,
+    raidId: string,
+    data: RAIDItemUpdate,
+  ): Promise<RAIDItem> {
+    try {
+      const response = await this.client.put<RAIDItem>(
+        `/projects/${projectKey}/raid/${raidId}`,
+        data,
+      );
+      return response.data;
+    } catch (error) {
+      return this.handleError(error);
+    }
+  }
+
+  async deleteRAIDItem(projectKey: string, raidId: string): Promise<{ message: string }> {
+    try {
+      const response = await this.client.delete<{ message: string }>(
+        `/projects/${projectKey}/raid/${raidId}`,
+      );
+      return response.data;
+    } catch (error) {
+      return this.handleError(error);
+    }
+  }
+}
+
+export const raidApiClient = new RaidApiClient();


### PR DESCRIPTION
# Summary

Refactor legacy `apiClient.ts` by extracting RAID CRUD/filter responsibilities into a dedicated domain client (`RaidApiClient`) while preserving the existing `apiClient` compatibility surface and normalizing delegated error-message behavior.

## Goal / Acceptance Criteria (required)

**Goal:** Decompose `apiClient.ts` into domain clients (beyond projects) with compatibility preserved and consistent migrated error behavior.
**Acceptance Criteria:**

- [x] `apiClient.ts` responsibility is reduced via domain extraction.
- [x] Migrated domains expose consistent success/error behavior.
- [x] Existing app flows remain functional.
- [x] Tests cover migrated client behavior.
- [x] Lint passes: `npm run lint`
- [x] Build passes: `npm run build`
- [x] Relevant client tests pass

## Issue / Tracking Link (required)

Fixes: #184

## What's Included

### Code changes

1. RAID domain extraction
   - `client/src/services/RaidApiClient.ts`
   - Added dedicated RAID domain client for list/get/create/update/delete operations with typed filters and typed error mapping to shared `ApiError` hierarchy.

2. Backward-compatible legacy facade delegation
   - `client/src/services/apiClient.ts`
   - Legacy RAID methods now delegate to `RaidApiClient` and keep the existing `ApiResponse<T>` contract.
   - Added shared delegated-domain error mapping helper used for migrated Project and RAID paths for consistent error semantics.

3. Migrated behavior tests
   - `client/src/test/unit/services/raidApiClient.test.tsx`
   - Replaced malformed tests with delegation/compatibility tests validating:
     - successful passthrough behavior
     - stable `ApiResponse` shape
     - delegated `ApiError` message propagation
     - consistent fallback for generic errors

## Validation (required)

### Automated checks

- [x] Lint passes
  - Command(s): `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm run lint`
  - Evidence: completed with 0 errors (6 existing warnings from coverage report files).

- [x] Build passes
  - Command(s): `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm run build`
  - Evidence: `✓ built in 4.38s`.

- [x] Tests pass
  - Command(s): `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm run test -- src/test/unit/services/raidApiClient.test.tsx`
  - Evidence: `Test Files 1 passed (1)`, `Tests 4 passed (4)`.

### Manual test evidence (required)

- [x] Manual test entry #1
  - Scenario: Existing callers use legacy `apiClient` RAID methods after extraction.
  - Expected result: methods still return `{ success, data|error }` compatibility shape.
  - Actual result / Evidence: compatibility assertions pass in `raidApiClient.test.tsx`.

- [x] Manual test entry #2
  - Scenario: Delegated RAID domain client throws typed and untyped errors.
  - Expected result: wrapper surfaces stable user-facing message text.
  - Actual result / Evidence: tests verify `ApiError` message propagation and generic `Error.message` fallback.

## How to review

1. Review new RAID domain client in `client/src/services/RaidApiClient.ts`.
2. Review RAID delegation + error helper in `client/src/services/apiClient.ts`.
3. Review backward-compat test coverage in `client/src/test/unit/services/raidApiClient.test.tsx`.
4. Run validation commands listed above and compare outcomes.

## Cross-repo / Downstream impact (always include)

- Related repos/services impacted: None.
- Backend/API contract impact: None.
