### PR TITLE
refactor(nav): consolidate to one canonical project-scoped navigation semantics

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import {
   BrowserRouter as Router,
   Routes,
   Route,
+  Navigate,
   useParams,
 } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -74,9 +75,7 @@ function App() {
                           <Route
                             path="/"
                             element={
-                              <ErrorBoundary name="ProjectList">
-                                <ProjectList />
-                              </ErrorBoundary>
+                              <Navigate to="/projects" replace />
                             }
                           />
                           <Route

--- a/client/src/components/AppNavigation.test.tsx
+++ b/client/src/components/AppNavigation.test.tsx
@@ -16,15 +16,9 @@ vi.mock('react-i18next', () => ({
         'nav.sections.projects': 'Projects',
         'nav.sections.create': 'Create',
         'nav.sections.manage': 'Manage',
-        'nav.sections.review': 'Review',
-        'nav.hints.assistedCreation': 'Open a project to start',
-        'nav.hints.readinessBuilder': 'Open a project to assess readiness',
-        'nav.assistedCreation': 'Assisted Creation',
         'nav.commands': 'Commands',
         'nav.apiTester': 'API Tester',
         'nav.uiLibrary': 'UI Library',
-        'nav.readinessBuilder': 'Readiness Builder',
-        'nav.badges.power': 'Pro',
         'nav.helpAvailable': 'Help is available for this feature',
       })[key] ?? key,
   }),
@@ -83,19 +77,16 @@ describe('AppNavigation', () => {
     expect(createSectionButton).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('shows explicit hints for project-scoped nav entries that route to projects', () => {
+  it('does not expose duplicate project-scoped shortcuts in global navigation', () => {
     render(
       <MemoryRouter initialEntries={['/projects']}>
         <AppNavigation connectionState="online" />
       </MemoryRouter>,
     );
 
-    const assistedCreationLink = screen.getByRole('link', { name: 'Assisted Creation Pro' });
-    expect(assistedCreationLink).toHaveAttribute('href', '/projects');
-    expect(screen.getByText('Open a project to start')).toBeInTheDocument();
-
-    const readinessBuilderLink = screen.getByRole('link', { name: 'Readiness Builder' });
-    expect(readinessBuilderLink).toHaveAttribute('href', '/projects');
-    expect(screen.getByText('Open a project to assess readiness')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Assisted Creation/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Readiness Builder/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Open a project to start/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Open a project to assess readiness/i)).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/AppNavigation.tsx
+++ b/client/src/components/AppNavigation.tsx
@@ -10,10 +10,8 @@ interface NavItem {
   key: string;
   labelKey: string;
   path: string;
-  hintKey?: string;
   icon?: string;
   primary?: boolean;
-  badgeKey?: string;
   helpAvailable?: boolean;
   helpPath?: string;
 }
@@ -35,7 +33,6 @@ export default function AppNavigation({ connectionState }: AppNavigationProps) {
     projects: true,
     create: true,
     manage: true,
-    review: true,
   });
 
   const sections: NavSection[] = useMemo(
@@ -72,16 +69,6 @@ export default function AppNavigation({ connectionState }: AppNavigationProps) {
         labelKey: 'nav.sections.create',
         items: [
           {
-            key: 'assisted-creation',
-            labelKey: 'nav.assistedCreation',
-            path: '/projects',
-            hintKey: 'nav.hints.assistedCreation',
-            icon: '⚡',
-            badgeKey: 'nav.badges.power',
-            helpAvailable: true,
-            helpPath: '/help/assisted-creation',
-          },
-          {
             key: 'commands',
             labelKey: 'nav.commands',
             path: '/commands',
@@ -106,21 +93,6 @@ export default function AppNavigation({ connectionState }: AppNavigationProps) {
             labelKey: 'nav.uiLibrary',
             path: '/ui',
             icon: '🧩',
-          },
-        ],
-      },
-      {
-        key: 'review',
-        labelKey: 'nav.sections.review',
-        items: [
-          {
-            key: 'readiness-builder',
-            labelKey: 'nav.readinessBuilder',
-            path: '/projects',
-            hintKey: 'nav.hints.readinessBuilder',
-            icon: '📋',
-            helpAvailable: true,
-            helpPath: '/help/readiness-builder',
           },
         ],
       },
@@ -222,9 +194,7 @@ export default function AppNavigation({ connectionState }: AppNavigationProps) {
                           {item.icon && <span className="app-nav__icon" aria-hidden="true">{item.icon}</span>}
                           <span className="app-nav__label-group">
                             <span className="app-nav__label">{t(item.labelKey)}</span>
-                            {item.hintKey && <span className="app-nav__hint" aria-hidden="true">{t(item.hintKey)}</span>}
                           </span>
-                          {item.badgeKey && <span className="app-nav__badge">{t(item.badgeKey)}</span>}
                         </NavLink>
                         {item.helpAvailable && item.helpPath && (
                           <NavLink

--- a/client/src/i18n/i18n.de.json
+++ b/client/src/i18n/i18n.de.json
@@ -9,22 +9,13 @@
     "openMenu": "Navigationsmenü öffnen",
     "closeMenu": "Navigationsmenü schließen",
     "helpAvailable": "Hilfe für diese Funktion verfügbar",
-    "assistedCreation": "Assisted Creation",
     "commands": "Befehle",
     "apiTester": "API-Tester",
     "uiLibrary": "UI-Bibliothek",
     "sections": {
       "projects": "Projekte",
       "create": "Erstellen",
-      "manage": "Verwalten",
-      "review": "Review"
-    },
-    "hints": {
-      "assistedCreation": "Projekt öffnen, um zu starten",
-      "readinessBuilder": "Projekt öffnen, um die Readiness zu prüfen"
-    },
-    "badges": {
-      "power": "Pro"
+      "manage": "Verwalten"
     },
     "projects": "Projekte",
     "guidedBuilder": "Guided Builder",

--- a/client/src/i18n/i18n.en.json
+++ b/client/src/i18n/i18n.en.json
@@ -9,22 +9,13 @@
     "openMenu": "Open navigation menu",
     "closeMenu": "Close navigation menu",
     "helpAvailable": "Help is available for this feature",
-    "assistedCreation": "Assisted Creation",
     "commands": "Commands",
     "apiTester": "API Tester",
     "uiLibrary": "UI Library",
     "sections": {
       "projects": "Projects",
       "create": "Create",
-      "manage": "Manage",
-      "review": "Review"
-    },
-    "hints": {
-      "assistedCreation": "Open a project to start",
-      "readinessBuilder": "Open a project to assess readiness"
-    },
-    "badges": {
-      "power": "Pro"
+      "manage": "Manage"
     },
     "projects": "Projects",
     "guidedBuilder": "Guided Builder",


### PR DESCRIPTION
# Summary

Consolidate navigation to one canonical project-scoped semantics by removing duplicate global shortcuts that mapped to `/projects` and making `/projects` the canonical projects landing route.

## Goal / Acceptance Criteria (required)

**Goal:** Keep global navigation project-agnostic and remove ambiguous duplicate semantics.

**Acceptance Criteria:**

- [x] Only one navigation semantics approach remains in code.
- [x] No dead components/routes for alternate approach remain.
- [x] Navigation tests align with canonical approach.
- [x] Lint passes: `npm run lint`
- [x] Build passes: `npm run build`
- [x] Relevant navigation tests pass

## Issue / Tracking Link (required)

Fixes: #194

## What's Included

### Code changes

1. Canonical route semantics in app routing
   - `client/src/App.tsx`
   - Root route now redirects to `/projects` via `<Navigate replace />`, making `/projects` the single canonical projects landing route.

2. Global nav semantics consolidated
   - `client/src/components/AppNavigation.tsx`
   - Removed duplicate project-scoped global shortcuts (`Assisted Creation`, `Readiness Builder`) that previously reused `/projects` with hint/badge semantics.
   - Removed now-dead `hintKey` and `badgeKey` nav item fields.

3. Test alignment with canonical behavior
   - `client/src/components/AppNavigation.test.tsx`
   - Replaced hint-based duplicate-route assertion with regression coverage that confirms duplicate project-scoped shortcuts are not present in global nav.

4. i18n consistency updates
   - `client/src/i18n/i18n.en.json`
   - `client/src/i18n/i18n.de.json`
   - Removed now-unused nav hint/badge/review-section keys tied to the alternate semantics while preserving still-used nav labels.

## Validation (required)

### Automated checks

- [x] Lint passes
  - Command(s): `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm run lint`
  - Evidence: Completed with `0 errors`; only existing warnings in generated `coverage/**` files (`Unused eslint-disable directive`).

- [x] Build passes
  - Command(s): `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm run build`
  - Evidence: `✓ built in 4.12s`.

- [x] Tests pass
  - Command(s): `cd /home/sw/work/AI-Agent-Framework/_external/AI-Agent-Framework-Client/client && npm test -- --run src/components/AppNavigation.test.tsx src/test/App.test.tsx`
  - Evidence: `Test Files 2 passed (2)`, `Tests 5 passed (5)`.

### Manual test evidence (required)

- [x] Manual test entry #1
  - Scenario: Open primary navigation in Projects view.
  - Expected result: Global nav includes project-agnostic entries only (no duplicate project-scoped shortcuts).
  - Actual result / Evidence: Regression test confirms `Assisted Creation` and `Readiness Builder` shortcuts are absent from global nav.

- [x] Manual test entry #2
  - Scenario: Navigate to app root (`/`).
  - Expected result: Root resolves to canonical projects landing semantics.
  - Actual result / Evidence: App routing now uses `<Navigate to="/projects" replace />`; route behavior is covered by app smoke test run.

## How to review

1. Review canonical root route redirect in `client/src/App.tsx`.
2. Review nav consolidation and removed duplicate semantics in `client/src/components/AppNavigation.tsx`.
3. Review updated navigation expectations in `client/src/components/AppNavigation.test.tsx`.
4. Review i18n cleanup in `client/src/i18n/i18n.en.json` and `client/src/i18n/i18n.de.json`.
5. Run the validation commands listed above.

## Cross-repo / Downstream impact (always include)

- Related repos/services impacted: None.
