### PR TITLE
test(ui): stabilize ArtifactList tests and state sync

### DIFF
--- a/client/src/components/AppNavigation.test.tsx
+++ b/client/src/components/AppNavigation.test.tsx
@@ -1,92 +1,114 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
-import AppNavigation from './AppNavigation';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import AppNavigation from "./AppNavigation";
 
-vi.mock('react-i18next', () => ({
+vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) =>
       ({
-        'nav.brand': 'AI Agent Framework',
-        'nav.primaryAria': 'Main navigation',
-        'nav.openMenu': 'Open navigation menu',
-        'nav.closeMenu': 'Close navigation menu',
-        'nav.guidedBuilder': 'Guided Builder',
-        'nav.projects': 'Projects',
-        'nav.sections.projects': 'Projects',
-        'nav.sections.create': 'Create',
-        'nav.sections.manage': 'Manage',
-        'nav.commands': 'Commands',
-        'nav.apiTester': 'API Tester',
-        'nav.uiLibrary': 'UI Library',
-        'nav.helpAvailable': 'Help is available for this feature',
+        "nav.brand": "AI Agent Framework",
+        "nav.primaryAria": "Main navigation",
+        "nav.openMenu": "Open navigation menu",
+        "nav.closeMenu": "Close navigation menu",
+        "nav.guidedBuilder": "Guided Builder",
+        "nav.projects": "Projects",
+        "nav.sections.projects": "Projects",
+        "nav.sections.create": "Create",
+        "nav.sections.manage": "Manage",
+        "nav.commands": "Commands",
+        "nav.apiTester": "API Tester",
+        "nav.uiLibrary": "UI Library",
+        "nav.helpAvailable": "Help is available for this feature",
       })[key] ?? key,
   }),
 }));
 
-vi.mock('./ConnectionStatus', () => ({
+vi.mock("./ConnectionStatus", () => ({
   default: () => <div>ConnectionStatus</div>,
 }));
 
-vi.mock('./LanguageSwitcher', () => ({
+vi.mock("./LanguageSwitcher", () => ({
   default: () => <div>LanguageSwitcher</div>,
 }));
 
-describe('AppNavigation', () => {
-  it('renders guided builder as primary nav item and main sections', () => {
+describe("AppNavigation", () => {
+  it("renders guided builder as primary nav item and main sections", () => {
     render(
-      <MemoryRouter initialEntries={['/projects']}>
+      <MemoryRouter initialEntries={["/projects"]}>
         <AppNavigation connectionState="online" />
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole('navigation', { name: 'Main navigation' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Guided Builder' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Help is available for this feature: Guided Builder/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Projects/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Create/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: "Main navigation" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Guided Builder" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: /Help is available for this feature: Guided Builder/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Projects/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Create/i })).toBeInTheDocument();
   });
 
-  it('highlights the active route', () => {
+  it("highlights the active route", () => {
     render(
-      <MemoryRouter initialEntries={['/guided-builder']}>
+      <MemoryRouter initialEntries={["/guided-builder"]}>
         <AppNavigation connectionState="online" />
       </MemoryRouter>,
     );
 
-    const guidedBuilderLink = screen.getByRole('link', { name: 'Guided Builder' });
-    expect(guidedBuilderLink.className).toContain('app-nav__item--active');
+    const guidedBuilderLink = screen.getByRole("link", {
+      name: "Guided Builder",
+    });
+    expect(guidedBuilderLink.className).toContain("app-nav__item--active");
   });
 
-  it('toggles mobile navigation and collapses sections', () => {
+  it("toggles mobile navigation and collapses sections", () => {
     render(
-      <MemoryRouter initialEntries={['/projects']}>
+      <MemoryRouter initialEntries={["/projects"]}>
         <AppNavigation connectionState="online" />
       </MemoryRouter>,
     );
 
-    const menuToggle = screen.getByRole('button', { name: /Open navigation menu/i });
+    const menuToggle = screen.getByRole("button", {
+      name: /Open navigation menu/i,
+    });
     fireEvent.click(menuToggle);
 
-    expect(menuToggle).toHaveAttribute('aria-label', 'Close navigation menu');
-    expect(menuToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(menuToggle).toHaveAttribute("aria-label", "Close navigation menu");
+    expect(menuToggle).toHaveAttribute("aria-expanded", "true");
 
-    const createSectionButton = screen.getByRole('button', { name: /Create/i });
-    expect(createSectionButton).toHaveAttribute('aria-expanded', 'true');
+    const createSectionButton = screen.getByRole("button", { name: /Create/i });
+    expect(createSectionButton).toHaveAttribute("aria-expanded", "true");
     fireEvent.click(createSectionButton);
-    expect(createSectionButton).toHaveAttribute('aria-expanded', 'false');
+    expect(createSectionButton).toHaveAttribute("aria-expanded", "false");
   });
 
-  it('does not expose duplicate project-scoped shortcuts in global navigation', () => {
+  it("does not expose duplicate project-scoped shortcuts in global navigation", () => {
     render(
-      <MemoryRouter initialEntries={['/projects']}>
+      <MemoryRouter initialEntries={["/projects"]}>
         <AppNavigation connectionState="online" />
       </MemoryRouter>,
     );
 
-    expect(screen.queryByRole('link', { name: /Assisted Creation/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /Readiness Builder/i })).not.toBeInTheDocument();
-    expect(screen.queryByText(/Open a project to start/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Open a project to assess readiness/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /Assisted Creation/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /Readiness Builder/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Open a project to start/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Open a project to assess readiness/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/ArtifactList.tsx
+++ b/client/src/components/ArtifactList.tsx
@@ -3,12 +3,15 @@
  * Displays project artifacts with navigation to editor
  */
 
-import React, { useEffect, useState, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
-import { ArtifactApiClient, type Artifact } from '../services/ArtifactApiClient';
-import { AuditApiClient } from '../services/AuditApiClient';
-import EmptyState from './ui/EmptyState';
-import './ArtifactList.css';
+import React, { useEffect, useState, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  ArtifactApiClient,
+  type Artifact,
+} from "../services/ArtifactApiClient";
+import { AuditApiClient } from "../services/AuditApiClient";
+import EmptyState from "./ui/EmptyState";
+import "./ArtifactList.css";
 
 interface ArtifactListProps {
   projectKey: string;
@@ -16,8 +19,8 @@ interface ArtifactListProps {
   onSelectArtifact?: (artifact: Artifact) => void;
 }
 
-type SortField = 'name' | 'date';
-type SortDirection = 'asc' | 'desc';
+type SortField = "name" | "date";
+type SortDirection = "asc" | "desc";
 
 export const ArtifactList: React.FC<ArtifactListProps> = ({
   projectKey,
@@ -28,11 +31,15 @@ export const ArtifactList: React.FC<ArtifactListProps> = ({
   const [artifacts, setArtifacts] = useState<Artifact[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [sortField, setSortField] = useState<SortField>('name');
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
-  const [auditIssuesMap, setAuditIssuesMap] = useState<Record<string, { hasErrors: boolean; hasWarnings: boolean }>>({});
+  const [sortField, setSortField] = useState<SortField>("name");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>(
+    {},
+  );
+  const [auditIssuesMap, setAuditIssuesMap] = useState<
+    Record<string, { hasErrors: boolean; hasWarnings: boolean }>
+  >({});
 
   const apiClient = useMemo(() => new ArtifactApiClient(), []);
   const auditClient = useMemo(() => new AuditApiClient(), []);
@@ -46,7 +53,9 @@ export const ArtifactList: React.FC<ArtifactListProps> = ({
         setArtifacts(data);
       } catch (err) {
         setError(
-          err instanceof Error ? err.message : t('art.list.errors.failedToLoad')
+          err instanceof Error
+            ? err.message
+            : t("art.list.errors.failedToLoad"),
         );
       } finally {
         setLoading(false);
@@ -62,19 +71,25 @@ export const ArtifactList: React.FC<ArtifactListProps> = ({
     const fetchAuditData = async () => {
       try {
         const auditResult = await auditClient.getAuditResults(projectKey);
-        const issuesMap: Record<string, { hasErrors: boolean; hasWarnings: boolean }> = {};
-        
+        const issuesMap: Record<
+          string,
+          { hasErrors: boolean; hasWarnings: boolean }
+        > = {};
+
         auditResult.issues.forEach((issue) => {
           if (!issuesMap[issue.artifact]) {
-            issuesMap[issue.artifact] = { hasErrors: false, hasWarnings: false };
+            issuesMap[issue.artifact] = {
+              hasErrors: false,
+              hasWarnings: false,
+            };
           }
-          if (issue.severity === 'error') {
+          if (issue.severity === "error") {
             issuesMap[issue.artifact].hasErrors = true;
-          } else if (issue.severity === 'warning') {
+          } else if (issue.severity === "warning") {
             issuesMap[issue.artifact].hasWarnings = true;
           }
         });
-        
+
         setAuditIssuesMap(issuesMap);
       } catch {
         // Audit data is optional - don't show error
@@ -91,16 +106,16 @@ export const ArtifactList: React.FC<ArtifactListProps> = ({
     const sorted = [...artifacts];
     sorted.sort((a, b) => {
       let comparison = 0;
-      
-      if (sortField === 'name') {
+
+      if (sortField === "name") {
         comparison = a.name.localeCompare(b.name);
-      } else if (sortField === 'date') {
-        const dateA = a.versions?.[0]?.date || '';
-        const dateB = b.versions?.[0]?.date || '';
+      } else if (sortField === "date") {
+        const dateA = a.versions?.[0]?.date || "";
+        const dateB = b.versions?.[0]?.date || "";
         comparison = dateA.localeCompare(dateB);
       }
 
-      return sortDirection === 'asc' ? comparison : -comparison;
+      return sortDirection === "asc" ? comparison : -comparison;
     });
     return sorted;
   }, [artifacts, sortField, sortDirection]);
@@ -112,38 +127,63 @@ export const ArtifactList: React.FC<ArtifactListProps> = ({
     }
 
     return sortedArtifacts.filter((artifact) => {
-      return artifact.name.toLowerCase().includes(query) || artifact.path.toLowerCase().includes(query);
+      return (
+        artifact.name.toLowerCase().includes(query) ||
+        artifact.path.toLowerCase().includes(query)
+      );
     });
   }, [sortedArtifacts, searchQuery]);
 
   const groupedArtifacts = useMemo(() => {
-    return filteredArtifacts.reduce<Record<string, Artifact[]>>((acc, artifact) => {
-      const pathParts = artifact.path.split('/');
-      const group = pathParts.length > 1 ? pathParts.slice(0, -1).join('/') : t('art.list.groups.root');
+    return filteredArtifacts.reduce<Record<string, Artifact[]>>(
+      (acc, artifact) => {
+        const pathParts = artifact.path.split("/");
+        const group =
+          pathParts.length > 1
+            ? pathParts.slice(0, -1).join("/")
+            : t("art.list.groups.root");
 
-      if (!acc[group]) {
-        acc[group] = [];
-      }
+        if (!acc[group]) {
+          acc[group] = [];
+        }
 
-      acc[group].push(artifact);
-      return acc;
-    }, {});
+        acc[group].push(artifact);
+        return acc;
+      },
+      {},
+    );
   }, [filteredArtifacts, t]);
 
   useEffect(() => {
-    const nextExpandedGroups: Record<string, boolean> = {};
-    Object.keys(groupedArtifacts).forEach((group) => {
-      nextExpandedGroups[group] = expandedGroups[group] ?? true;
+    setExpandedGroups((previousGroups) => {
+      const nextExpandedGroups: Record<string, boolean> = {};
+      Object.keys(groupedArtifacts).forEach((group) => {
+        nextExpandedGroups[group] = previousGroups[group] ?? true;
+      });
+
+      const previousKeys = Object.keys(previousGroups);
+      const nextKeys = Object.keys(nextExpandedGroups);
+
+      if (previousKeys.length !== nextKeys.length) {
+        return nextExpandedGroups;
+      }
+
+      for (const key of nextKeys) {
+        if (previousGroups[key] !== nextExpandedGroups[key]) {
+          return nextExpandedGroups;
+        }
+      }
+
+      return previousGroups;
     });
-    setExpandedGroups(nextExpandedGroups);
   }, [groupedArtifacts]);
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
-      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
     } else {
       setSortField(field);
-      setSortDirection('asc');
+      setSortDirection("asc");
     }
   };
 
@@ -161,13 +201,13 @@ export const ArtifactList: React.FC<ArtifactListProps> = ({
   };
 
   if (loading) {
-    return <div className="artifact-list-loading">{t('art.list.loading')}</div>;
+    return <div className="artifact-list-loading">{t("art.list.loading")}</div>;
   }
 
   if (error) {
     return (
       <div className="artifact-list-error">
-        {t('art.list.errors.loadingWithMessage', { message: error })}
+        {t("art.list.errors.loadingWithMessage", { message: error })}
       </div>
     );
   }
@@ -175,13 +215,13 @@ export const ArtifactList: React.FC<ArtifactListProps> = ({
   return (
     <div className="artifact-list">
       <div className="artifact-list-header">
-        <h2>{t('art.list.title')}</h2>
+        <h2>{t("art.list.title")}</h2>
         <button
           className="btn-create-artifact"
           onClick={onCreateNew}
-          aria-label={t('art.list.actions.createNewAria')}
+          aria-label={t("art.list.actions.createNewAria")}
         >
-          {t('art.list.actions.createNew')}
+          {t("art.list.actions.createNew")}
         </button>
       </div>
 
@@ -189,35 +229,39 @@ export const ArtifactList: React.FC<ArtifactListProps> = ({
         <input
           type="search"
           className="artifact-search-input"
-          placeholder={t('art.list.search.placeholder')}
+          placeholder={t("art.list.search.placeholder")}
           value={searchQuery}
           onChange={(event) => setSearchQuery(event.target.value)}
-          aria-label={t('art.list.search.aria')}
+          aria-label={t("art.list.search.aria")}
         />
       </div>
 
       {artifacts.length === 0 ? (
         <EmptyState
           icon="📄"
-          title={t('art.list.empty.title')}
-          description={t('art.list.empty.description')}
-          ctaLabel={t('art.list.cta.create')}
+          title={t("art.list.empty.title")}
+          description={t("art.list.empty.description")}
+          ctaLabel={t("art.list.cta.create")}
           ctaAction={() => onCreateNew?.()}
         />
       ) : filteredArtifacts.length === 0 ? (
         <div className="artifact-no-results" role="status" aria-live="polite">
-          <h3>{t('art.list.search.noResults.title')}</h3>
-          <p>{t('art.list.search.noResults.description')}</p>
+          <h3>{t("art.list.search.noResults.title")}</h3>
+          <p>{t("art.list.search.noResults.description")}</p>
           <button
             className="artifact-search-clear"
-            onClick={() => setSearchQuery('')}
+            onClick={() => setSearchQuery("")}
             type="button"
           >
-            {t('art.list.search.clear')}
+            {t("art.list.search.clear")}
           </button>
         </div>
       ) : (
-        <div className="artifact-explorer" role="tree" aria-label={t('art.list.groups.aria')}>
+        <div
+          className="artifact-explorer"
+          role="tree"
+          aria-label={t("art.list.groups.aria")}
+        >
           {Object.entries(groupedArtifacts).map(([groupName, groupItems]) => {
             const isExpanded = expandedGroups[groupName] ?? true;
 
@@ -230,39 +274,65 @@ export const ArtifactList: React.FC<ArtifactListProps> = ({
                   aria-expanded={isExpanded}
                 >
                   <span className="artifact-group-chevron" aria-hidden="true">
-                    {isExpanded ? '▾' : '▸'}
+                    {isExpanded ? "▾" : "▸"}
                   </span>
                   <span className="artifact-group-name">{groupName}</span>
-                  <span className="artifact-group-count">{groupItems.length}</span>
+                  <span className="artifact-group-count">
+                    {groupItems.length}
+                  </span>
                 </button>
 
                 {isExpanded && (
                   <table className="artifact-list-table">
                     <thead>
                       <tr>
-                        <th className="artifact-status-col" title="Audit Status">
-                          {t('art.list.columns.status')}
+                        <th
+                          className="artifact-status-col"
+                          title="Audit Status"
+                        >
+                          {t("art.list.columns.status")}
                         </th>
-                        <th onClick={() => handleSort('name')} className="sortable">
-                          {t('art.list.columns.name')} {sortField === 'name' && (sortDirection === 'asc' ? '↑' : '↓')}
+                        <th
+                          onClick={() => handleSort("name")}
+                          className="sortable"
+                        >
+                          {t("art.list.columns.name")}{" "}
+                          {sortField === "name" &&
+                            (sortDirection === "asc" ? "↑" : "↓")}
                         </th>
-                        <th>{t('art.list.columns.type')}</th>
-                        <th>{t('art.list.columns.path')}</th>
-                        <th onClick={() => handleSort('date')} className="sortable">
-                          {t('art.list.columns.lastModified')} {sortField === 'date' && (sortDirection === 'asc' ? '↑' : '↓')}
+                        <th>{t("art.list.columns.type")}</th>
+                        <th>{t("art.list.columns.path")}</th>
+                        <th
+                          onClick={() => handleSort("date")}
+                          className="sortable"
+                        >
+                          {t("art.list.columns.lastModified")}{" "}
+                          {sortField === "date" &&
+                            (sortDirection === "asc" ? "↑" : "↓")}
                         </th>
                       </tr>
                     </thead>
                     <tbody>
                       {groupItems.map((artifact) => {
-                        const auditStatus = auditIssuesMap[artifact.name] || { hasErrors: false, hasWarnings: false };
-                        const statusIcon = auditStatus.hasErrors ? '✗' : auditStatus.hasWarnings ? '⚠' : '✓';
-                        const statusClass = auditStatus.hasErrors ? 'error' : auditStatus.hasWarnings ? 'warning' : 'success';
-                        const statusTitle = auditStatus.hasErrors
-                          ? 'Has errors'
+                        const auditStatus = auditIssuesMap[artifact.name] || {
+                          hasErrors: false,
+                          hasWarnings: false,
+                        };
+                        const statusIcon = auditStatus.hasErrors
+                          ? "✗"
                           : auditStatus.hasWarnings
-                          ? 'Has warnings'
-                          : 'Complete';
+                            ? "⚠"
+                            : "✓";
+                        const statusClass = auditStatus.hasErrors
+                          ? "error"
+                          : auditStatus.hasWarnings
+                            ? "warning"
+                            : "success";
+                        const statusTitle = auditStatus.hasErrors
+                          ? "Has errors"
+                          : auditStatus.hasWarnings
+                            ? "Has warnings"
+                            : "Complete";
 
                         return (
                           <tr
@@ -270,13 +340,18 @@ export const ArtifactList: React.FC<ArtifactListProps> = ({
                             onClick={() => handleArtifactClick(artifact)}
                             className="artifact-row"
                           >
-                            <td className={`artifact-status artifact-status--${statusClass}`} title={statusTitle}>
+                            <td
+                              className={`artifact-status artifact-status--${statusClass}`}
+                              title={statusTitle}
+                            >
                               {statusIcon}
                             </td>
                             <td className="artifact-name">{artifact.name}</td>
                             <td>{artifact.type}</td>
-                            <td className="artifact-path" title={artifact.path}>{artifact.path}</td>
-                            <td>{artifact.versions?.[0]?.date || 'N/A'}</td>
+                            <td className="artifact-path" title={artifact.path}>
+                              {artifact.path}
+                            </td>
+                            <td>{artifact.versions?.[0]?.date || "N/A"}</td>
                           </tr>
                         );
                       })}

--- a/client/src/components/__tests__/ArtifactList.test.tsx
+++ b/client/src/components/__tests__/ArtifactList.test.tsx
@@ -2,14 +2,17 @@
  * ArtifactList Component Tests
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { ArtifactList } from '../ArtifactList';
-import { ArtifactApiClient, type Artifact } from '../../services/ArtifactApiClient';
-import { AuditApiClient } from '../../services/AuditApiClient';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ArtifactList } from "../ArtifactList";
+import {
+  ArtifactApiClient,
+  type Artifact,
+} from "../../services/ArtifactApiClient";
+import { AuditApiClient } from "../../services/AuditApiClient";
 
-vi.mock('react-i18next', () => ({
+vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, options?: { defaultValue?: string; message?: string }) => {
       if (options?.defaultValue) {
@@ -17,26 +20,28 @@ vi.mock('react-i18next', () => ({
       }
 
       const translations: Record<string, string> = {
-        'art.list.loading': 'Loading artifacts...',
-        'art.list.title': 'Artifacts',
-        'art.list.columns.status': 'Status',
-        'art.list.columns.name': 'Name',
-        'art.list.columns.type': 'Type',
-        'art.list.columns.path': 'Path',
-        'art.list.columns.lastModified': 'Last Modified',
-        'art.list.groups.aria': 'Artifact explorer groups',
-        'art.list.groups.root': 'Root',
-        'art.list.search.placeholder': 'Search by artifact name or path...',
-        'art.list.search.aria': 'Search artifacts by name or path',
-        'art.list.search.clear': 'Clear search',
-        'art.list.search.noResults.title': 'No artifacts match your search',
-        'art.list.search.noResults.description': 'Try a different name/path or clear the filter.',
-        'art.list.actions.createNew': 'Create New Artifact',
-        'art.list.actions.createNewAria': 'Create new artifact',
-        'art.list.empty.title': 'No artifacts yet',
-        'art.list.empty.description': 'Create your first artifact to get started.',
-        'art.list.cta.create': 'Create New Artifact',
-        'art.list.errors.loadingWithMessage': `Error: ${options?.message ?? ''}`,
+        "art.list.loading": "Loading artifacts...",
+        "art.list.title": "Artifacts",
+        "art.list.columns.status": "Status",
+        "art.list.columns.name": "Name",
+        "art.list.columns.type": "Type",
+        "art.list.columns.path": "Path",
+        "art.list.columns.lastModified": "Last Modified",
+        "art.list.groups.aria": "Artifact explorer groups",
+        "art.list.groups.root": "Root",
+        "art.list.search.placeholder": "Search by artifact name or path...",
+        "art.list.search.aria": "Search artifacts by name or path",
+        "art.list.search.clear": "Clear search",
+        "art.list.search.noResults.title": "No artifacts match your search",
+        "art.list.search.noResults.description":
+          "Try a different name/path or clear the filter.",
+        "art.list.actions.createNew": "Create New Artifact",
+        "art.list.actions.createNewAria": "Create new artifact",
+        "art.list.empty.title": "No artifacts yet",
+        "art.list.empty.description":
+          "Create your first artifact to get started.",
+        "art.list.cta.create": "Create New Artifact",
+        "art.list.errors.loadingWithMessage": `Error: ${options?.message ?? ""}`,
       };
 
       return translations[key] ?? key;
@@ -44,32 +49,32 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-describe('ArtifactList', () => {
-  const mockProjectKey = 'TEST-001';
+describe("ArtifactList", () => {
+  const mockProjectKey = "TEST-001";
   const mockArtifacts: Artifact[] = [
     {
-      path: 'artifacts/charter.md',
-      name: 'charter.md',
-      type: 'md',
-      versions: [{ version: 'current', date: '2026-01-15T10:00:00Z' }],
+      path: "artifacts/charter.md",
+      name: "charter.md",
+      type: "md",
+      versions: [{ version: "current", date: "2026-01-15T10:00:00Z" }],
     },
     {
-      path: 'artifacts/raid.md',
-      name: 'raid.md',
-      type: 'md',
-      versions: [{ version: 'current', date: '2026-01-20T12:00:00Z' }],
+      path: "artifacts/raid.md",
+      name: "raid.md",
+      type: "md",
+      versions: [{ version: "current", date: "2026-01-20T12:00:00Z" }],
     },
     {
-      path: 'artifacts/wbs.md',
-      name: 'wbs.md',
-      type: 'md',
-      versions: [{ version: 'current', date: '2026-01-10T08:00:00Z' }],
+      path: "artifacts/wbs.md",
+      name: "wbs.md",
+      type: "md",
+      versions: [{ version: "current", date: "2026-01-10T08:00:00Z" }],
     },
   ];
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    vi.spyOn(AuditApiClient.prototype, 'getAuditResults').mockResolvedValue({
+    vi.spyOn(AuditApiClient.prototype, "getAuditResults").mockResolvedValue({
       projectKey: mockProjectKey,
       timestamp: new Date().toISOString(),
       issues: [],
@@ -81,44 +86,55 @@ describe('ArtifactList', () => {
     });
   });
 
-  it('renders loading state initially', () => {
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue([]);
+  it("renders loading state initially", () => {
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockImplementation(
+      () => new Promise(() => {}),
+    );
+    vi.spyOn(AuditApiClient.prototype, "getAuditResults").mockImplementation(
+      () => new Promise(() => {}),
+    );
 
     render(<ArtifactList projectKey={mockProjectKey} />);
 
-    expect(screen.getByText('Loading artifacts...')).toBeInTheDocument();
+    expect(screen.getByText("Loading artifacts...")).toBeInTheDocument();
   });
 
-  it('renders artifact list after successful fetch', async () => {
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue(mockArtifacts);
+  it("renders artifact list after successful fetch", async () => {
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockResolvedValue(
+      mockArtifacts,
+    );
 
     render(<ArtifactList projectKey={mockProjectKey} />);
 
     await waitFor(() => {
-      expect(screen.getByText('charter.md')).toBeInTheDocument();
+      expect(screen.getByText("charter.md")).toBeInTheDocument();
     });
 
-    expect(screen.getByText('raid.md')).toBeInTheDocument();
-    expect(screen.getByText('wbs.md')).toBeInTheDocument();
-    expect(screen.getByText('artifacts')).toBeInTheDocument();
-    expect(screen.getByText('artifacts/charter.md')).toBeInTheDocument();
+    expect(screen.getByText("raid.md")).toBeInTheDocument();
+    expect(screen.getByText("wbs.md")).toBeInTheDocument();
+    expect(screen.getByText("artifacts")).toBeInTheDocument();
+    expect(screen.getByText("artifacts/charter.md")).toBeInTheDocument();
   });
 
-  it('renders empty state when no artifacts exist', async () => {
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue([]);
+  it("renders empty state when no artifacts exist", async () => {
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockResolvedValue(
+      [],
+    );
 
     render(<ArtifactList projectKey={mockProjectKey} />);
 
     await waitFor(() => {
       expect(screen.getByText(/No artifacts yet/i)).toBeInTheDocument();
       expect(
-        screen.getByText(/Create your first artifact to get started./i)
+        screen.getByText(/Create your first artifact to get started./i),
       ).toBeInTheDocument();
     });
   });
 
-  it('renders error state on fetch failure', async () => {
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockRejectedValue(new Error('Network error'));
+  it("renders error state on fetch failure", async () => {
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockRejectedValue(
+      new Error("Network error"),
+    );
 
     render(<ArtifactList projectKey={mockProjectKey} />);
 
@@ -128,207 +144,259 @@ describe('ArtifactList', () => {
   });
 
   it('renders "Create New Artifact" button', async () => {
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue(mockArtifacts);
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockResolvedValue(
+      mockArtifacts,
+    );
 
     render(<ArtifactList projectKey={mockProjectKey} />);
 
     await waitFor(() => {
-      expect(screen.getByText('charter.md')).toBeInTheDocument();
+      expect(screen.getByText("charter.md")).toBeInTheDocument();
     });
 
-    const createButton = screen.getByRole('button', { name: /create new artifact/i });
+    const createButton = screen.getByRole("button", {
+      name: /create new artifact/i,
+    });
     expect(createButton).toBeInTheDocument();
   });
 
   it('calls onCreateNew when "Create New Artifact" is clicked', async () => {
     const mockOnCreateNew = vi.fn();
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue(mockArtifacts);
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockResolvedValue(
+      mockArtifacts,
+    );
 
     const user = userEvent.setup();
-    render(<ArtifactList projectKey={mockProjectKey} onCreateNew={mockOnCreateNew} />);
+    render(
+      <ArtifactList
+        projectKey={mockProjectKey}
+        onCreateNew={mockOnCreateNew}
+      />,
+    );
 
     await waitFor(() => {
-      expect(screen.getByText('charter.md')).toBeInTheDocument();
+      expect(screen.getByText("charter.md")).toBeInTheDocument();
     });
 
-    const createButton = screen.getByRole('button', { name: /create new artifact/i });
+    const createButton = screen.getByRole("button", {
+      name: /create new artifact/i,
+    });
     await user.click(createButton);
 
     expect(mockOnCreateNew).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onSelectArtifact when artifact row is clicked', async () => {
+  it("calls onSelectArtifact when artifact row is clicked", async () => {
     const mockOnSelectArtifact = vi.fn();
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue(mockArtifacts);
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockResolvedValue(
+      mockArtifacts,
+    );
 
     const user = userEvent.setup();
-    render(<ArtifactList projectKey={mockProjectKey} onSelectArtifact={mockOnSelectArtifact} />);
+    render(
+      <ArtifactList
+        projectKey={mockProjectKey}
+        onSelectArtifact={mockOnSelectArtifact}
+      />,
+    );
 
     await waitFor(() => {
-      expect(screen.getByText('charter.md')).toBeInTheDocument();
+      expect(screen.getByText("charter.md")).toBeInTheDocument();
     });
 
-    const charterRow = screen.getByText('charter.md').closest('tr');
+    const charterRow = screen.getByText("charter.md").closest("tr");
     await user.click(charterRow!);
 
     expect(mockOnSelectArtifact).toHaveBeenCalledTimes(1);
     expect(mockOnSelectArtifact).toHaveBeenCalledWith(mockArtifacts[0]);
   });
 
-  it('sorts artifacts by name in ascending order by default', async () => {
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue(mockArtifacts);
+  it("sorts artifacts by name in ascending order by default", async () => {
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockResolvedValue(
+      mockArtifacts,
+    );
 
     render(<ArtifactList projectKey={mockProjectKey} />);
 
     await waitFor(() => {
-      expect(screen.getByText('charter.md')).toBeInTheDocument();
+      expect(screen.getByText("charter.md")).toBeInTheDocument();
     });
 
-    const rows = screen.getAllByRole('row');
+    const rows = screen.getAllByRole("row");
     // Skip header row (index 0)
-    const artifactNames = rows.slice(1).map(row => within(row).getAllByRole('cell')[1].textContent);
-    
-    expect(artifactNames).toEqual(['charter.md', 'raid.md', 'wbs.md']);
+    const artifactNames = rows
+      .slice(1)
+      .map((row) => within(row).getAllByRole("cell")[1].textContent);
+
+    expect(artifactNames).toEqual(["charter.md", "raid.md", "wbs.md"]);
   });
 
-  it('sorts artifacts by name in descending order when name header clicked twice', async () => {
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue(mockArtifacts);
+  it("sorts artifacts by name in descending order when name header clicked twice", async () => {
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockResolvedValue(
+      mockArtifacts,
+    );
 
     const user = userEvent.setup();
     render(<ArtifactList projectKey={mockProjectKey} />);
 
     await waitFor(() => {
-      expect(screen.getByText('charter.md')).toBeInTheDocument();
+      expect(screen.getByText("charter.md")).toBeInTheDocument();
     });
 
     const nameHeader = screen.getByText(/Name/);
-    
+
     // First click - already sorted asc by default, should toggle to desc
     await user.click(nameHeader);
 
-    const rows = screen.getAllByRole('row');
-    const artifactNames = rows.slice(1).map(row => within(row).getAllByRole('cell')[1].textContent);
-    
-    expect(artifactNames).toEqual(['wbs.md', 'raid.md', 'charter.md']);
+    const rows = screen.getAllByRole("row");
+    const artifactNames = rows
+      .slice(1)
+      .map((row) => within(row).getAllByRole("cell")[1].textContent);
+
+    expect(artifactNames).toEqual(["wbs.md", "raid.md", "charter.md"]);
   });
 
-  it('sorts artifacts by date when date header is clicked', async () => {
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue(mockArtifacts);
+  it("sorts artifacts by date when date header is clicked", async () => {
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockResolvedValue(
+      mockArtifacts,
+    );
 
     const user = userEvent.setup();
     render(<ArtifactList projectKey={mockProjectKey} />);
 
     await waitFor(() => {
-      expect(screen.getByText('charter.md')).toBeInTheDocument();
+      expect(screen.getByText("charter.md")).toBeInTheDocument();
     });
 
     const dateHeader = screen.getByText(/Last Modified/);
     await user.click(dateHeader);
 
-    const rows = screen.getAllByRole('row');
-    const artifactNames = rows.slice(1).map(row => within(row).getAllByRole('cell')[1].textContent);
-    
+    const rows = screen.getAllByRole("row");
+    const artifactNames = rows
+      .slice(1)
+      .map((row) => within(row).getAllByRole("cell")[1].textContent);
+
     // Sorted by date ascending: wbs (Jan 10) -> charter (Jan 15) -> raid (Jan 20)
-    expect(artifactNames).toEqual(['wbs.md', 'charter.md', 'raid.md']);
+    expect(artifactNames).toEqual(["wbs.md", "charter.md", "raid.md"]);
   });
 
-  it('filters artifacts by search query (name or path)', async () => {
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue(mockArtifacts);
+  it("filters artifacts by search query (name or path)", async () => {
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockResolvedValue(
+      mockArtifacts,
+    );
 
-    const user = userEvent.setup();
     render(<ArtifactList projectKey={mockProjectKey} />);
 
     await waitFor(() => {
-      expect(screen.getByText('charter.md')).toBeInTheDocument();
+      expect(screen.getByText("charter.md")).toBeInTheDocument();
     });
 
-    const searchInput = screen.getByRole('searchbox', {
+    const searchInput = screen.getByRole("searchbox", {
       name: /search artifacts by name or path/i,
     });
-    await user.type(searchInput, 'raid');
+    fireEvent.change(searchInput, { target: { value: "raid" } });
 
-    expect(screen.getByText('raid.md')).toBeInTheDocument();
-    expect(screen.queryByText('charter.md')).not.toBeInTheDocument();
-    expect(screen.queryByText('wbs.md')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(searchInput).toHaveValue("raid");
+      expect(screen.getByText("raid.md")).toBeInTheDocument();
+      expect(screen.queryByText("charter.md")).not.toBeInTheDocument();
+      expect(screen.queryByText("wbs.md")).not.toBeInTheDocument();
+    });
   });
 
-  it('groups artifacts by directory path and supports collapsing groups', async () => {
+  it("groups artifacts by directory path and supports collapsing groups", async () => {
     const groupedArtifacts: Artifact[] = [
       {
-        path: 'artifacts/planning/charter.md',
-        name: 'charter.md',
-        type: 'md',
-        versions: [{ version: 'current', date: '2026-01-15T10:00:00Z' }],
+        path: "artifacts/planning/charter.md",
+        name: "charter.md",
+        type: "md",
+        versions: [{ version: "current", date: "2026-01-15T10:00:00Z" }],
       },
       {
-        path: 'artifacts/controls/raid.md',
-        name: 'raid.md',
-        type: 'md',
-        versions: [{ version: 'current', date: '2026-01-20T12:00:00Z' }],
+        path: "artifacts/controls/raid.md",
+        name: "raid.md",
+        type: "md",
+        versions: [{ version: "current", date: "2026-01-20T12:00:00Z" }],
       },
     ];
 
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue(groupedArtifacts);
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockResolvedValue(
+      groupedArtifacts,
+    );
 
     const user = userEvent.setup();
     render(<ArtifactList projectKey={mockProjectKey} />);
 
     await waitFor(() => {
-      expect(screen.getByText('artifacts/planning')).toBeInTheDocument();
-      expect(screen.getByText('artifacts/controls')).toBeInTheDocument();
+      expect(screen.getByText("artifacts/planning")).toBeInTheDocument();
+      expect(screen.getByText("artifacts/controls")).toBeInTheDocument();
     });
 
-    const planningToggle = screen.getByRole('button', { name: /artifacts\/planning/i });
-    expect(planningToggle).toHaveAttribute('aria-expanded', 'true');
+    const planningToggle = screen.getByRole("button", {
+      name: /artifacts\/planning/i,
+    });
+    expect(planningToggle).toHaveAttribute("aria-expanded", "true");
     await user.click(planningToggle);
-    expect(planningToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(planningToggle).toHaveAttribute("aria-expanded", "false");
   });
 
-  it('shows a no-results state when search has no match', async () => {
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue(mockArtifacts);
+  it("shows a no-results state when search has no match", async () => {
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockResolvedValue(
+      mockArtifacts,
+    );
 
-    const user = userEvent.setup();
     render(<ArtifactList projectKey={mockProjectKey} />);
 
     await waitFor(() => {
-      expect(screen.getByText('charter.md')).toBeInTheDocument();
+      expect(screen.getByText("charter.md")).toBeInTheDocument();
     });
 
-    const searchInput = screen.getByRole('searchbox', {
+    const searchInput = screen.getByRole("searchbox", {
       name: /search artifacts by name or path/i,
     });
-    await user.type(searchInput, 'does-not-exist');
+    fireEvent.change(searchInput, { target: { value: "does-not-exist" } });
 
-    expect(screen.getByText('No artifacts match your search')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /clear search/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(searchInput).toHaveValue("does-not-exist");
+      expect(
+        screen.getByText("No artifacts match your search"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /clear search/i }),
+      ).toBeInTheDocument();
+    });
   });
 
   it('displays "N/A" for artifacts without version dates', async () => {
     const artifactsWithoutDates: Artifact[] = [
-      { path: 'artifacts/test.md', name: 'test.md', type: 'md' },
+      { path: "artifacts/test.md", name: "test.md", type: "md" },
     ];
-    
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue(artifactsWithoutDates);
+
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockResolvedValue(
+      artifactsWithoutDates,
+    );
 
     render(<ArtifactList projectKey={mockProjectKey} />);
 
     await waitFor(() => {
-      expect(screen.getByText('test.md')).toBeInTheDocument();
+      expect(screen.getByText("test.md")).toBeInTheDocument();
     });
 
-    expect(screen.getByText('N/A')).toBeInTheDocument();
+    expect(screen.getByText("N/A")).toBeInTheDocument();
   });
 
-  it('displays artifact type correctly', async () => {
-    vi.spyOn(ArtifactApiClient.prototype, 'listArtifacts').mockResolvedValue(mockArtifacts);
+  it("displays artifact type correctly", async () => {
+    vi.spyOn(ArtifactApiClient.prototype, "listArtifacts").mockResolvedValue(
+      mockArtifacts,
+    );
 
     render(<ArtifactList projectKey={mockProjectKey} />);
 
     await waitFor(() => {
-      expect(screen.getByText('charter.md')).toBeInTheDocument();
+      expect(screen.getByText("charter.md")).toBeInTheDocument();
     });
 
-    const mdTypes = screen.getAllByText('md');
+    const mdTypes = screen.getAllByText("md");
     expect(mdTypes.length).toBe(3); // All test artifacts are .md files
   });
 });

--- a/client/src/i18n/i18n.test.ts
+++ b/client/src/i18n/i18n.test.ts
@@ -12,18 +12,16 @@ const hasTranslationPath = (
   obj: Record<string, unknown>,
   path: string,
 ): boolean => {
-  const value = path
-    .split(".")
-    .reduce<unknown>((current, key) => {
-      if (
-        typeof current === "object" &&
-        current !== null &&
-        key in (current as Record<string, unknown>)
-      ) {
-        return (current as Record<string, unknown>)[key];
-      }
-      return undefined;
-    }, obj);
+  const value = path.split(".").reduce<unknown>((current, key) => {
+    if (
+      typeof current === "object" &&
+      current !== null &&
+      key in (current as Record<string, unknown>)
+    ) {
+      return (current as Record<string, unknown>)[key];
+    }
+    return undefined;
+  }, obj);
 
   return typeof value === "string";
 };
@@ -137,12 +135,12 @@ describe("i18n Translation Catalogs", () => {
       ];
 
       requiredProjectScopedKeys.forEach((key) => {
-        expect(hasTranslationPath(enTranslations as Record<string, unknown>, key)).toBe(
-          true,
-        );
-        expect(hasTranslationPath(deTranslations as Record<string, unknown>, key)).toBe(
-          true,
-        );
+        expect(
+          hasTranslationPath(enTranslations as Record<string, unknown>, key),
+        ).toBe(true);
+        expect(
+          hasTranslationPath(deTranslations as Record<string, unknown>, key),
+        ).toBe(true);
       });
     });
   });


### PR DESCRIPTION
# Summary
Stabilize ArtifactList UI tests by removing render-churn in group expansion sync and making search assertions deterministic, while keeping related navigation/i18n tests aligned with current formatting/style.

## Goal / Acceptance Criteria (required)
- [x] ArtifactList tests no longer trigger the prior worker/OOM instability path.
- [x] Search and no-results assertions are deterministic.
- [x] Lint and targeted UI/i18n tests pass locally.

## Issue / Tracking Link (required)
Fixes: None

## Validation (required)
- Updated `ArtifactList` group expansion effect to avoid no-op state updates that caused repeated re-renders.
- Updated `ArtifactList` tests to use deterministic input changes and proper async waits.
- Kept related touched test files (`AppNavigation.test.tsx`, `i18n.test.ts`) in sync and passing.

## Automated checks
- [x] Lint passes
- Command(s): `cd client && npm run lint`
- Evidence: Pass

- [x] Build passes
- Command(s): `cd client && npm run test -- src/components/__tests__/ArtifactList.test.tsx src/components/AppNavigation.test.tsx src/i18n/i18n.test.ts`
- Evidence: Pass (3 files, 29 tests)

## Manual test evidence (required)
- [x] Manual test entry #1
- Scenario: Run ArtifactList-focused unit suite after state-sync/test stabilization.
- Expected result: ArtifactList test cases complete without worker crash and pass deterministically.
- Actual result / Evidence: `src/components/__tests__/ArtifactList.test.tsx` passed (15/15) in targeted run; combined targeted suite passed (29/29).

## Cross-repo / Downstream impact (always include)
- Related repos/services impacted: None

## How to review
1. Review `client/src/components/ArtifactList.tsx` effect logic for no-op guard and stable state updates.
2. Review `client/src/components/__tests__/ArtifactList.test.tsx` search/loading test updates.
3. Confirm targeted checks listed above are sufficient for this test-stability-only change.