### PR TITLE
feat(sidebar): deterministic grouping/order + scope/state distinction

### DIFF
--- a/client/src/components/AppNavigation.css
+++ b/client/src/components/AppNavigation.css
@@ -183,6 +183,22 @@
   margin-left: 0.4rem;
 }
 
+.app-nav__item--scope-global {
+  border-left: 2px solid transparent;
+}
+
+.app-nav__item--scope-project {
+  border-left: 2px solid #4f46e5;
+}
+
+.app-nav__item--state-inactive {
+  opacity: 0.96;
+}
+
+.app-nav__item--state-active {
+  opacity: 1;
+}
+
 .app-nav__item--primary {
   background: linear-gradient(135deg, #4f46e5 0%, #312e81 100%);
   color: #ffffff;
@@ -212,8 +228,29 @@
 .app-nav__label-group {
   flex: 1;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.4rem;
   min-width: 0;
+}
+
+.app-nav__scope-badge {
+  flex-shrink: 0;
+  font-size: 0.62rem;
+  line-height: 1;
+  border-radius: 9999px;
+  padding: 0.18rem 0.35rem;
+  font-weight: 700;
+}
+
+.app-nav__scope-badge--global {
+  background: #f3f4f6;
+  color: #4b5563;
+}
+
+.app-nav__scope-badge--project {
+  background: #e0e7ff;
+  color: #3730a3;
 }
 
 .app-nav__hint {

--- a/client/src/components/AppNavigation.test.tsx
+++ b/client/src/components/AppNavigation.test.tsx
@@ -15,11 +15,19 @@ vi.mock("react-i18next", () => ({
         "projects.list.cta.new": "Create Project",
         "nav.projects": "Projects",
         "nav.sections.projects": "Projects",
+        "nav.sections.currentProject": "Current Project",
         "nav.sections.create": "Create",
         "nav.sections.manage": "Manage",
         "nav.commands": "Commands",
         "nav.apiTester": "API Tester",
         "nav.uiLibrary": "UI Library",
+        "nav.artifactBuilder": "Artifact Builder",
+        "nav.readinessBuilder": "Readiness Builder",
+        "nav.raid": "RAID",
+        "projectView.tabs.proposeChanges": "Propose Changes",
+        "projectView.tabs.applyProposals": "Apply Proposals",
+        "projectView.tabs.audit": "Audit",
+        "ac.title": "Assisted Creation",
         "nav.helpAvailable": "Help is available for this feature",
       })[key] ?? key,
   }),
@@ -121,5 +129,80 @@ describe("AppNavigation", () => {
     expect(
       screen.queryByText(/Open a project to assess readiness/i),
     ).not.toBeInTheDocument();
+  });
+
+  it("renders deterministic section and project item order", () => {
+    render(
+      <MemoryRouter initialEntries={["/projects/alpha-proj/audit"]}>
+        <AppNavigation connectionState="online" />
+      </MemoryRouter>,
+    );
+
+    const projectsButton = screen.getByRole("button", { name: /Projects/i });
+    const currentProjectButton = screen.getByRole("button", {
+      name: /Current Project/i,
+    });
+    const createButton = screen.getByRole("button", { name: /Create/i });
+    const manageButton = screen.getByRole("button", { name: /Manage/i });
+
+    expect(
+      projectsButton.compareDocumentPosition(currentProjectButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      currentProjectButton.compareDocumentPosition(createButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      createButton.compareDocumentPosition(manageButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    const artifactLink = screen.getByRole("link", { name: "Artifact Builder" });
+    const assistedLink = screen.getByRole("link", { name: "Assisted Creation" });
+    const readinessLink = screen.getByRole("link", { name: "Readiness Builder" });
+    const proposeLink = screen.getByRole("link", { name: "Propose Changes" });
+    const applyLink = screen.getByRole("link", { name: "Apply Proposals" });
+    const raidLink = screen.getByRole("link", { name: "RAID" });
+    const auditLink = screen.getByRole("link", { name: "Audit" });
+
+    expect(
+      artifactLink.compareDocumentPosition(assistedLink) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      assistedLink.compareDocumentPosition(readinessLink) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      readinessLink.compareDocumentPosition(proposeLink) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      proposeLink.compareDocumentPosition(applyLink) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      applyLink.compareDocumentPosition(raidLink) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      raidLink.compareDocumentPosition(auditLink) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("shows scope markers for global and project scoped entries", () => {
+    render(
+      <MemoryRouter initialEntries={["/projects/alpha-proj/artifacts"]}>
+        <AppNavigation connectionState="online" />
+      </MemoryRouter>,
+    );
+
+    const projectsLink = screen.getByRole("link", { name: "Projects" });
+    const artifactLink = screen.getByRole("link", { name: "Artifact Builder" });
+
+    expect(projectsLink).toHaveTextContent("GLB");
+    expect(artifactLink).toHaveTextContent("PRJ");
   });
 });


### PR DESCRIPTION
# Summary
- Make sidebar grouping and ordering deterministic using explicit `order` metadata for sections/items plus stable sort helpers.
- Add basic visual distinction for nav item scope/type-state using low-weight `GLB`/`PRJ` markers and scope/state classes.
- Add focused tests that lock section ordering and project-item ordering behavior.

## Goal / Acceptance Criteria (required)
- [x] Sidebar grouping/order logic is clearer and deterministic.
- [x] Type/state is reflected in UI with a basic visual distinction.
- [x] Tests cover the new grouping/order logic.

## Issue / Tracking Link (required)
Fixes: #238
- Parent/split context: migrated from backend issue #440 to client repo for proper UX traceability.

## Validation (required)
- Focused test: `npm run test -- --run src/components/AppNavigation.test.tsx` → pass (6/6).
- Full test suite: `npm run test -- --run` → pass (80 files, 883 passed, 5 skipped).
- Lint: `npm run lint` → pass.
- Build: `npm run build` → pass.

## Automated checks
- [x] Lint passes
- Command(s): `npm run lint`
- Evidence: local run succeeded with no eslint errors.

- [x] Build passes
- Command(s): `npm run build`
- Evidence: local run succeeded; production bundle generated.

## Manual test evidence (required)
- [x] Manual test entry #1
- Scenario: Open project-scoped route and inspect sidebar section/item ordering and scope markers.
- Expected result: Sections/items render in deterministic order; global vs project entries are visually distinct.
- Actual result / Evidence: Verified deterministic section order (`Projects -> Current Project -> Create -> Manage`) and project item order (`Artifacts -> Assisted Creation -> Readiness -> Propose -> Apply -> RAID -> Audit`) with visible scope markers.

## Cross-repo / Downstream impact (always include)
- Related repos/services impacted: `blecx/AI-Agent-Framework` (tracking-only migration context), no backend API contract changes.
- Follow-up required: None.

## UX / Navigation Review
- [x] blecs-ux-authority consulted and pass recorded for this UI-affecting slice.
- [x] UX_DECISION: PASS
- [x] Scope held to minimal sidebar grouping/order + visual distinction only.

## How to review
1. Open sidebar on `/projects/<key>/audit` and confirm section order is `Projects`, `Current Project`, `Create`, `Manage`.
2. Expand `Current Project` and verify item order is deterministic: `Artifact Builder`, `Assisted Creation`, `Readiness Builder`, `Propose Changes`, `Apply Proposals`, `RAID`, `Audit`.
3. Verify basic visual distinction: project-scoped items show `PRJ`, global items show `GLB`, and active/inactive state styling remains clear.
4. Run `npm run test -- --run src/components/AppNavigation.test.tsx` and confirm the new order/scope tests pass.
